### PR TITLE
feature: upgrade jq from 1.4 to 1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 RUN apt-get update && \
     apt-get install -y curl && \
     apt-get purge && apt-get clean && apt-get autoclean && \
-    curl -o /usr/local/bin/jq http://stedolan.github.io/jq/download/linux64/jq && \
+    curl -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq
 COPY --from=builder /workspace/kubectl-opslevel /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 RUN apt-get update && \
     apt-get install -y curl && \
     apt-get purge && apt-get clean && apt-get autoclean && \
-    curl -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+    curl -L -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq
 COPY --from=builder /workspace/kubectl-opslevel /usr/local/bin/
 


### PR DESCRIPTION
I noticed this is running jq 1.4. 
I'm not sure why what's under release is 1.4 but some of the filtering features are not available in that version and I can't make use of the new exclude feature unless I bump to 1.6.

So here it is.