### PR TITLE
feature: adds support for reading api tokens from the filesystem usin…

### DIFF
--- a/src/common/client.go
+++ b/src/common/client.go
@@ -15,7 +15,7 @@ func NewClient() *opslevel.Client {
 	clientErr := client.Validate()
 	if clientErr != nil {
 		if strings.Contains(clientErr.Error(), "Please provide a valid OpsLevel API token") {
-			cobra.CheckErr(fmt.Errorf("%s via 'export OL_APITOKEN=XXX' or '--api-token=XXX'", clientErr.Error()))
+			cobra.CheckErr(fmt.Errorf("%s via 'export OL_APITOKEN=XXX' or '--api-token=XXX' or '--api-token-path=/path/to/token/file'", clientErr.Error()))
 		} else {
 			cobra.CheckErr(clientErr)
 		}


### PR DESCRIPTION
Proposal: Support reading an OpsLevel API token from a file.

This is specifically to support running as a CronJob in Kubernetes where using a Kubernetes Secret mounted as an Environment Variable is not possible. The alternative of using `--api-token` would require reading the API key from somewhere first, likely the filesystem (eg. `--api-token=$(cat ./api-token)`), so the preference is to support this directly.