### PR TITLE
bugfix: skip over aliases that are empty strings as they are not valid to register

### DIFF
--- a/src/cmd/import.go
+++ b/src/cmd/import.go
@@ -219,7 +219,7 @@ func UpdateService(client *opslevel.Client, registration common.ServiceRegistrat
 
 func AssignAliases(client *opslevel.Client, registration common.ServiceRegistration, service *opslevel.Service) {
 	for _, alias := range registration.Aliases {
-		if service.HasAlias(alias) {
+		if alias == "" || service.HasAlias(alias) {
 			continue
 		}
 		_, err := client.CreateAlias(opslevel.AliasCreateInput{

--- a/src/common/service.go
+++ b/src/common/service.go
@@ -215,11 +215,15 @@ func Parse(c config.ServiceRegistrationConfig, count int, resources []byte) ([]S
 	return services, nil
 }
 
+// Also removes empty string values
 func removeDuplicates(data []string) []string {
 	keys := make(map[string]bool)
 	list := []string{}
 
 	for _, entry := range data {
+		if entry == "" {
+			continue
+		}
 		if _, value := keys[entry]; !value {
 			keys[entry] = true
 			list = append(list, entry)


### PR DESCRIPTION
closes #79