### PR TITLE
Bump jq to v1.6

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,6 +3,6 @@ ENV USER_UID=1001 USER_NAME=opslevel
 ENTRYPOINT ["/usr/local/bin/kubectl-opslevel"]
 WORKDIR /app
 RUN apt-get update && \
-    apt-get install -y curl jq && \
+    apt-get install -y jq && \
     apt-get purge && apt-get clean && apt-get autoclean
 COPY kubectl-opslevel /usr/local/bin

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,8 +3,6 @@ ENV USER_UID=1001 USER_NAME=opslevel
 ENTRYPOINT ["/usr/local/bin/kubectl-opslevel"]
 WORKDIR /app
 RUN apt-get update && \
-    apt-get install -y curl && \
-    apt-get purge && apt-get clean && apt-get autoclean && \
-    curl -o /usr/local/bin/jq http://stedolan.github.io/jq/download/linux64/jq && \
-    chmod +x /usr/local/bin/jq
+    apt-get install -y curl jq && \
+    apt-get purge && apt-get clean && apt-get autoclean
 COPY kubectl-opslevel /usr/local/bin


### PR DESCRIPTION
Install `jq` from the OS repository, so that the integrity of the binary can be ensured with apt. This also bumps the version of `jq` to v1.6, it was previously pulling in v1.4.