### PR TITLE
Add new command to send k8s resources as payloads to CEC

### DIFF
--- a/.changes/unreleased/Feature-20220717-114349.yaml
+++ b/.changes/unreleased/Feature-20220717-114349.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add command `collect` to send k8s payloads to custom even checks
+time: 2022-07-17T11:43:49.361472-05:00

--- a/src/cmd/collect.go
+++ b/src/cmd/collect.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/opslevel/kubectl-opslevel/common"
+	"github.com/opslevel/kubectl-opslevel/config"
+	"github.com/opslevel/kubectl-opslevel/jq"
+	"github.com/opslevel/kubectl-opslevel/k8sutils"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	collectResyncInterval int
+	collectBatchSize      int
+)
+
+var collectCmd = &cobra.Command{
+	Use:   "collect",
+	Short: "Acts as a kubernetes controller to collect resources for submission to OpsLevel as custom event check payloads",
+	Long:  `Acts as a kubernetes controller to collect resources for submission to OpsLevel as custom event check payloads`,
+	Run:   runCollect,
+}
+
+func init() {
+	rootCmd.AddCommand(collectCmd)
+
+	collectCmd.Flags().StringP("integration-url", "i", "", "OpsLevel integration url (OPSLEVEL_INTEGRATION_URL)")
+	collectCmd.Flags().IntVar(&collectResyncInterval, "resync", 24, "The amount (in hours) before a full resync of the kubernetes cluster happens with OpsLevel. [default: 24]")
+	collectCmd.Flags().IntVar(&collectBatchSize, "batch", 500, "The max amount of k8s resources to batch process. Helps to speedup initial startup. [default: 500]")
+
+	viper.BindEnv("integration-url", "OPSLEVEL_INTEGRATION_URL")
+}
+
+func runCollect(cmd *cobra.Command, args []string) {
+	config, configErr := config.New()
+	cobra.CheckErr(configErr)
+
+	jq.ValidateInstalled()
+
+	integrationUrl := viper.GetString("integration-url")
+	if len(integrationUrl) <= 0 {
+		cobra.CheckErr(fmt.Errorf("please specify --integration-url"))
+	}
+
+	k8sClient := k8sutils.CreateKubernetesClient()
+
+	resync := time.Hour * time.Duration(reconcileResyncInterval)
+	collectQueue := make(chan string, 1)
+
+	for i, importConfig := range config.Service.Collect {
+		selector := importConfig.SelectorConfig
+		if selectorErr := selector.Validate(); selectorErr != nil {
+			log.Fatal().Err(selectorErr)
+			return
+		}
+		gvr, err := k8sClient.GetGVR(selector)
+		if err != nil {
+			log.Error().Err(err)
+			continue
+		}
+		callback := createCollectHandler(fmt.Sprintf("service.import[%d]", i), importConfig, collectQueue)
+		controller := k8sutils.NewController(*gvr, resync, reconcileBatchSize)
+		controller.OnAdd = callback
+		controller.OnUpdate = callback
+		go controller.Start(1)
+	}
+
+	// Loop forever waiting to collect 1 payload at a time
+	go func() {
+		restClient := createRestClient()
+		for {
+			for payload := range collectQueue {
+				restClient.R().SetBody(payload).Post(integrationUrl)
+			}
+		}
+	}()
+
+	k8sutils.Start()
+}
+
+func createCollectHandler(field string, config config.Collect, queue chan string) k8sutils.KubernetesControllerHandler {
+	id := fmt.Sprintf("%s/%s", config.SelectorConfig.ApiVersion, config.SelectorConfig.Kind)
+	return func(items []interface{}) {
+		var resources [][]byte
+		for _, item := range items {
+			data, _ := json.Marshal(item)
+			resources = append(resources, data)
+		}
+		filtered := common.FilterResources(config.SelectorConfig, resources)
+		log.Info().Msgf("[%s] Processing '%d' payload(s)", id, len(filtered))
+		for _, payload := range filtered {
+			queue <- string(payload)
+		}
+	}
+}

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -15,7 +15,7 @@ import (
 
 // Make sure we only use spaces inside of these samples
 var configSimple = []byte(`#Simple Opslevel CLI Config
-version: "1.1.0"
+version: "1.2.0"
 service:
   import:
     - selector: # This limits what data we look at in Kubernetes
@@ -35,11 +35,17 @@ service:
             - .metadata.labels
           create: # tag with the same key name but with a different value with be added to the service
             - '{"environment": .spec.template.metadata.labels.environment}'
-
+  collect:
+    - selector: # This limits what data we look at in Kubernetes
+        apiVersion: apps/v1 # only supports resources found in 'kubectl api-resources --verbs="get,list"'
+        kind: Deployment
+        excludes: # filters out resources if any expression returns truthy
+          - .metadata.namespace == "kube-system"
+          - .metadata.annotations."opslevel.com/ignore"
 `)
 
 var configSample = []byte(`#Sample Opslevel CLI Config
-version: "1.1.0"
+version: "1.2.0"
 service:
   import:
     - selector: # This limits what data we look at in Kubernetes
@@ -77,7 +83,13 @@ service:
           - .metadata.annotations.repo
           # find annotations with format: opslevel.com/repo.<displayname>.<repo.subpath.dots.turned.to.forwardslash>: <opslevel repo alias> 
           - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/repos"))) | map({"name": .key | split(".")[2], "directory": .key | split(".")[3:] | join("/"), "repo": .value})'
-
+  collect:
+    - selector: # This limits what data we look at in Kubernetes
+        apiVersion: apps/v1 # only supports resources found in 'kubectl api-resources --verbs="get,list"'
+        kind: Deployment
+        excludes: # filters out resources if any expression returns truthy
+          - .metadata.namespace == "kube-system"
+          - .metadata.annotations."opslevel.com/ignore"
 `)
 
 var configCmd = &cobra.Command{

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/go-resty/resty/v2"
 	"os"
 	"runtime"
 	"strings"
@@ -45,7 +46,7 @@ func init() {
 	rootCmd.PersistentFlags().String("log-level", "INFO", "overrides environment variable 'OPSLEVEL_LOG_LEVEL' (options [\"ERROR\", \"WARN\", \"INFO\", \"DEBUG\"])")
 	rootCmd.PersistentFlags().StringVar(&apiToken, "api-token", "", "The OpsLevel API Token. Overrides environment variable 'OPSLEVEL_API_TOKEN' and the argument 'api-token-path'")
 	rootCmd.PersistentFlags().StringVar(&apiTokenFile, "api-token-path", "", "Absolute path to a file containing the OpsLevel API Token. Overrides environment variable 'OPSLEVEL_API_TOKEN'")
-	rootCmd.PersistentFlags().String("api-url", "https://api.opslevel.com/graphql", "The OpsLevel API Url. Overrides environment variable 'OPSLEVEL_API_URL'")
+	rootCmd.PersistentFlags().String("api-url", "https://api.opslevel.com/", "The OpsLevel API Url. Overrides environment variable 'OPSLEVEL_API_URL'")
 	rootCmd.PersistentFlags().IntVar(&apiTimeout, "api-timeout", 40, "The OpsLevel API timeout in seconds. Overrides environment variable 'OPSLEVEL_API_TIMEOUT'")
 	rootCmd.PersistentFlags().IntP("workers", "w", -1, "Sets the number of workers for API call processing. -1 == # CPU cores (cgroup aware). Overrides environment variable 'OPSLEVEL_WORKERS'")
 	rootCmd.PersistentFlags().StringP("output", "o", "text", "Output format.  One of: json|text")
@@ -53,7 +54,7 @@ func init() {
 	viper.BindPFlags(rootCmd.PersistentFlags())
 	viper.BindEnv("log-format", "OPSLEVEL_LOG_FORMAT", "OL_LOG_FORMAT", "OL_LOGFORMAT")
 	viper.BindEnv("log-level", "OPSLEVEL_LOG_LEVEL", "OL_LOG_LEVEL", "OL_LOGLEVEL")
-	viper.BindEnv("api-url", "OPSLEVEL_API_URL", "OL_API_URL", "OL_APIURL")
+	viper.BindEnv("api-url", "OPSLEVEL_API_URL", "OL_API_URL", "OL_APIURL", "OPSLEVEL_APP_URL", "OL_APP_URL")
 	viper.BindEnv("api-token", "OPSLEVEL_API_TOKEN", "OL_API_TOKEN", "OL_APITOKEN")
 	viper.BindEnv("api-timeout", "OPSLEVEL_API_TIMEOUT")
 	viper.BindEnv("workers", "OPSLEVEL_WORKERS", "OL_WORKERS")
@@ -181,4 +182,8 @@ func createOpslevelClient() *opslevel.Client {
 	}
 	cobra.CheckErr(clientErr)
 	return client
+}
+
+func createRestClient() *resty.Client {
+	return opslevel.NewRestClient(opslevel.SetURL(viper.GetString("api-url")))
 }

--- a/src/common/service.go
+++ b/src/common/service.go
@@ -370,7 +370,7 @@ func anyIsTrue(resourceIndex int, filters []*JQResponseMulti) bool {
 
 }
 
-func filterResources(selector k8sutils.KubernetesSelector, resources [][]byte) [][]byte {
+func FilterResources(selector k8sutils.KubernetesSelector, resources [][]byte) [][]byte {
 	var output [][]byte
 	resourceCount := len(resources)
 	// Parse
@@ -495,7 +495,7 @@ func GetAllServices(c *config.Config) ([]ServiceRegistration, error) {
 }
 
 func ProcessResources(field string, config config.Import, resources [][]byte) ([]ServiceRegistration, error) {
-	filtered := filterResources(config.SelectorConfig, resources)
+	filtered := FilterResources(config.SelectorConfig, resources)
 	if len(filtered) < 1 {
 		return []ServiceRegistration{}, nil
 	}

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	ConfigCurrentVersion = "1.1.0"
+	ConfigCurrentVersion = "1.2.0"
 )
 
 type TagRegistrationConfig struct {
@@ -39,8 +39,13 @@ type Import struct {
 	OpslevelConfig ServiceRegistrationConfig   `yaml:"opslevel" json:"opslevel" mapstructure:"opslevel"`
 }
 
+type Collect struct {
+	SelectorConfig k8sutils.KubernetesSelector `yaml:"selector" json:"selector" mapstructure:"selector"`
+}
+
 type Service struct {
-	Import []Import `json:"import"`
+	Import  []Import  `json:"import"`
+	Collect []Collect `json:"collect"`
 }
 
 type Config struct {


### PR DESCRIPTION
usage:

```sh
kubectl opslevel collect -i "https://app.opslevel.com/integrations/custom_event/eeb1f18e-7205-41a5-97fe-60a0657f062d" -f ./opslevel-k8s.yaml
```

This then spins up as a kubernetes controller watching for changes to k8s resources and submits them individually as payloads to the integration url.

By submitting them individually it will both reduce the load on our API server AND only submit payloads when changes to the k8s resources actually happen.

It is built ontop of the existing selectors in opslevel-k8s.yaml the idea being if you are using `kubectl opslevel reconcile` then you may also want to get those same things as payloads for custom event checks.
