### PR TITLE
Option to disable service creation when reconciling services

### DIFF
--- a/.changes/unreleased/Feature-20231220-200719.yaml
+++ b/.changes/unreleased/Feature-20231220-200719.yaml
@@ -1,0 +1,4 @@
+kind: Feature
+body: Add option to disable automatic Service creation by passing --disable-service-create
+  OR setting OL_DISABLE_SERVICE_CREATE=1
+time: 2023-12-20T20:07:19.590353-05:00

--- a/src/cmd/import.go
+++ b/src/cmd/import.go
@@ -19,7 +19,7 @@ var importCmd = &cobra.Command{
 		common.SyncCache(client)
 		queue := make(chan opslevel_jq_parser.ServiceRegistration, 1)
 		common.SetupControllers(config, queue, 0)
-		common.ReconcileServices(client, queue)
+		common.ReconcileServices(client, disableServiceCreation, queue)
 		log.Info().Msg("Import Complete")
 	},
 }

--- a/src/cmd/reconcile.go
+++ b/src/cmd/reconcile.go
@@ -8,12 +8,10 @@ import (
 
 	"github.com/opslevel/kubectl-opslevel/common"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
 	reconcileResyncInterval int
-	disableServiceCreation  bool
 )
 
 var reconcileCmd = &cobra.Command{
@@ -25,7 +23,6 @@ var reconcileCmd = &cobra.Command{
 		cobra.CheckErr(err)
 
 		client := createOpslevelClient()
-		disableServiceCreation := viper.GetBool("disable-service-create")
 		common.SyncCache(client)
 		resync := time.Hour * time.Duration(reconcileResyncInterval)
 		common.SyncCaches(createOpslevelClient(), resync)
@@ -39,9 +36,4 @@ var reconcileCmd = &cobra.Command{
 func init() {
 	serviceCmd.AddCommand(reconcileCmd)
 	reconcileCmd.Flags().IntVar(&reconcileResyncInterval, "resync", 24, "The amount (in hours) before a full resync of the kubernetes cluster happens with OpsLevel. [default: 24]")
-
-	viper.SetDefault("disable-service-create", false)
-	reconcileCmd.Flags().Bool("disable-service-create", false, "Turns off automatic service creation (service data will still be reconciled). Overrides environment variable 'OPSLEVEL_DISABLE_SERVICE_CREATE'.")
-	viper.BindPFlag("disable-service-create", reconcileCmd.Flags().Lookup("disable-service-create"))
-	viper.BindEnv("disable-service-create", "OPSLEVEL_DISABLE_SERVICE_CREATE", "OL_DISABLE_SERVICE_CREATE")
 }

--- a/src/cmd/reconcile.go
+++ b/src/cmd/reconcile.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"time"
+
 	opslevel_common "github.com/opslevel/opslevel-common/v2023"
 	opslevel_jq_parser "github.com/opslevel/opslevel-jq-parser/v2023"
-	"time"
 
 	"github.com/opslevel/kubectl-opslevel/common"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -35,4 +37,9 @@ var reconcileCmd = &cobra.Command{
 func init() {
 	serviceCmd.AddCommand(reconcileCmd)
 	reconcileCmd.Flags().IntVar(&reconcileResyncInterval, "resync", 24, "The amount (in hours) before a full resync of the kubernetes cluster happens with OpsLevel. [default: 24]")
+
+	viper.SetDefault("disable-service-create", false)
+	reconcileCmd.Flags().Bool("disable-service-create", false, "Turns off automatic service creation (service data will still be reconciled). Overrides environment variable 'OPSLEVEL_DISABLE_SERVICE_CREATE'.")
+	viper.BindPFlag("disable-service-create", reconcileCmd.Flags().Lookup("disable-service-create"))
+	viper.BindEnv("disable-service-create", "OPSLEVEL_DISABLE_SERVICE_CREATE", "OL_DISABLE_SERVICE_CREATE")
 }

--- a/src/cmd/reconcile.go
+++ b/src/cmd/reconcile.go
@@ -23,6 +23,8 @@ var reconcileCmd = &cobra.Command{
 		config, err := LoadConfig()
 		cobra.CheckErr(err)
 
+		common.DisableServiceCreation = viper.GetBool("disable-service-create")
+
 		client := createOpslevelClient()
 		common.SyncCache(client)
 		resync := time.Hour * time.Duration(reconcileResyncInterval)

--- a/src/cmd/reconcile.go
+++ b/src/cmd/reconcile.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	reconcileResyncInterval int
+	disableServiceCreation  bool
 )
 
 var reconcileCmd = &cobra.Command{
@@ -23,15 +24,14 @@ var reconcileCmd = &cobra.Command{
 		config, err := LoadConfig()
 		cobra.CheckErr(err)
 
-		common.DisableServiceCreation = viper.GetBool("disable-service-create")
-
 		client := createOpslevelClient()
+		disableServiceCreation := viper.GetBool("disable-service-create")
 		common.SyncCache(client)
 		resync := time.Hour * time.Duration(reconcileResyncInterval)
 		common.SyncCaches(createOpslevelClient(), resync)
 		queue := make(chan opslevel_jq_parser.ServiceRegistration, 1)
 		common.SetupControllers(config, queue, resync)
-		common.ReconcileServices(client, queue)
+		common.ReconcileServices(client, disableServiceCreation, queue)
 		opslevel_common.Run("Controller")
 	},
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -51,7 +51,6 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&apiTimeout, "api-timeout", 40, "The OpsLevel API timeout in seconds. Overrides environment variable 'OPSLEVEL_API_TIMEOUT'")
 	rootCmd.PersistentFlags().IntP("workers", "w", -1, "Sets the number of workers for API call processing. -1 == # CPU cores (cgroup aware). Overrides environment variable 'OPSLEVEL_WORKERS'")
 	rootCmd.PersistentFlags().StringP("output", "o", "text", "Output format.  One of: json|text")
-	rootCmd.PersistentFlags().Bool("disable-service-create", false, "Turns off automatic service creation (service data will still be reconciled). Overrides environment variable 'OPSLEVEL_DISABLE_SERVICE_CREATE' (options [\"false\",\"true\"])")
 
 	viper.BindPFlags(rootCmd.PersistentFlags())
 	viper.BindEnv("log-format", "OPSLEVEL_LOG_FORMAT", "OL_LOG_FORMAT", "OL_LOGFORMAT")
@@ -60,7 +59,6 @@ func init() {
 	viper.BindEnv("api-token", "OPSLEVEL_API_TOKEN", "OL_API_TOKEN", "OL_APITOKEN")
 	viper.BindEnv("api-timeout", "OPSLEVEL_API_TIMEOUT")
 	viper.BindEnv("workers", "OPSLEVEL_WORKERS", "OL_WORKERS")
-	viper.BindEnv("disable-service-create", "OPSLEVEL_DISABLE_SERVICE_CREATE", "OL_DISABLE_SERVICE_CREATE")
 	cobra.OnInitialize(func() {
 		readConfig()
 		setupLogging()

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -21,12 +21,13 @@ import (
 )
 
 var (
-	apiToken     string
-	apiTokenFile string
-	apiTimeout   int
-	cfgFile      string
-	concurrency  int
-	outputFormat string
+	apiToken               string
+	apiTokenFile           string
+	apiTimeout             int
+	cfgFile                string
+	concurrency            int
+	outputFormat           string
+	disableServiceCreation bool
 )
 
 var rootCmd = &cobra.Command{
@@ -51,6 +52,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&apiTimeout, "api-timeout", 40, "The OpsLevel API timeout in seconds. Overrides environment variable 'OPSLEVEL_API_TIMEOUT'")
 	rootCmd.PersistentFlags().IntP("workers", "w", -1, "Sets the number of workers for API call processing. -1 == # CPU cores (cgroup aware). Overrides environment variable 'OPSLEVEL_WORKERS'")
 	rootCmd.PersistentFlags().StringP("output", "o", "text", "Output format.  One of: json|text")
+	rootCmd.PersistentFlags().Bool("disable-service-create", false, "Turns off automatic service creation (service data will still be reconciled). Overrides environment variable 'OPSLEVEL_DISABLE_SERVICE_CREATE'.")
 
 	viper.BindPFlags(rootCmd.PersistentFlags())
 	viper.BindEnv("log-format", "OPSLEVEL_LOG_FORMAT", "OL_LOG_FORMAT", "OL_LOGFORMAT")
@@ -59,12 +61,17 @@ func init() {
 	viper.BindEnv("api-token", "OPSLEVEL_API_TOKEN", "OL_API_TOKEN", "OL_APITOKEN")
 	viper.BindEnv("api-timeout", "OPSLEVEL_API_TIMEOUT")
 	viper.BindEnv("workers", "OPSLEVEL_WORKERS", "OL_WORKERS")
+	viper.BindEnv("disable-service-create", "OPSLEVEL_DISABLE_SERVICE_CREATE", "OL_DISABLE_SERVICE_CREATE")
 	cobra.OnInitialize(func() {
 		readConfig()
 		setupLogging()
 		setupOutput()
 		setupConcurrency()
 		setupAPIToken()
+		disableServiceCreation = viper.GetBool("disable-service-create")
+		if disableServiceCreation {
+			log.Info().Msgf("Service creation is disabled.")
+		}
 	})
 }
 

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -51,6 +51,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&apiTimeout, "api-timeout", 40, "The OpsLevel API timeout in seconds. Overrides environment variable 'OPSLEVEL_API_TIMEOUT'")
 	rootCmd.PersistentFlags().IntP("workers", "w", -1, "Sets the number of workers for API call processing. -1 == # CPU cores (cgroup aware). Overrides environment variable 'OPSLEVEL_WORKERS'")
 	rootCmd.PersistentFlags().StringP("output", "o", "text", "Output format.  One of: json|text")
+	rootCmd.PersistentFlags().Bool("disable-service-create", false, "Turns off automatic service creation (service data will still be reconciled). Overrides environment variable 'OPSLEVEL_DISABLE_SERVICE_CREATE' (options [\"false\",\"true\"])")
 
 	viper.BindPFlags(rootCmd.PersistentFlags())
 	viper.BindEnv("log-format", "OPSLEVEL_LOG_FORMAT", "OL_LOG_FORMAT", "OL_LOGFORMAT")
@@ -59,6 +60,7 @@ func init() {
 	viper.BindEnv("api-token", "OPSLEVEL_API_TOKEN", "OL_API_TOKEN", "OL_APITOKEN")
 	viper.BindEnv("api-timeout", "OPSLEVEL_API_TIMEOUT")
 	viper.BindEnv("workers", "OPSLEVEL_WORKERS", "OL_WORKERS")
+	viper.BindEnv("disable-service-create", "OPSLEVEL_DISABLE_SERVICE_CREATE", "OL_DISABLE_SERVICE_CREATE")
 	cobra.OnInitialize(func() {
 		readConfig()
 		setupLogging()

--- a/src/common/client.go
+++ b/src/common/client.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"github.com/opslevel/opslevel-go/v2023"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 )
 
 type OpslevelClient struct {
@@ -25,9 +27,6 @@ func (c *OpslevelClient) GetService(alias string) (*opslevel.Service, error) {
 }
 
 func (c *OpslevelClient) CreateService(input opslevel.ServiceCreateInput) (*opslevel.Service, error) {
-	if c.CreateServiceHandler == nil {
-		return nil, nil
-	}
 	return c.CreateServiceHandler(input)
 }
 
@@ -93,6 +92,10 @@ func NewOpslevelClient(client *opslevel.Client) *OpslevelClient {
 			return client.GetServiceWithAlias(alias)
 		},
 		CreateServiceHandler: func(input opslevel.ServiceCreateInput) (*opslevel.Service, error) {
+			if viper.GetBool("disable-service-create") {
+				log.Info().Msgf("[%s] Not creating a new service\n\tREASON: service creation is disabled", input.Name)
+				return nil, nil
+			}
 			return client.CreateService(input)
 		},
 		UpdateServiceHandler: func(input opslevel.ServiceUpdateInput) (*opslevel.Service, error) {

--- a/src/common/client.go
+++ b/src/common/client.go
@@ -2,8 +2,6 @@ package common
 
 import (
 	"github.com/opslevel/opslevel-go/v2023"
-	"github.com/rs/zerolog/log"
-	"github.com/spf13/viper"
 )
 
 type OpslevelClient struct {
@@ -95,10 +93,6 @@ func NewOpslevelClient(client *opslevel.Client) *OpslevelClient {
 			return client.GetServiceWithAlias(alias)
 		},
 		CreateServiceHandler: func(input opslevel.ServiceCreateInput) (*opslevel.Service, error) {
-			if viper.GetBool("disable-service-create") {
-				log.Info().Msgf("[%s] Not creating a new service\n\tREASON: service creation is disabled", input.Name)
-				return nil, nil
-			}
 			return client.CreateService(input)
 		},
 		UpdateServiceHandler: func(input opslevel.ServiceUpdateInput) (*opslevel.Service, error) {

--- a/src/common/client.go
+++ b/src/common/client.go
@@ -27,6 +27,9 @@ func (c *OpslevelClient) GetService(alias string) (*opslevel.Service, error) {
 }
 
 func (c *OpslevelClient) CreateService(input opslevel.ServiceCreateInput) (*opslevel.Service, error) {
+	if c.CreateServiceHandler == nil {
+		return nil, nil
+	}
 	return c.CreateServiceHandler(input)
 }
 

--- a/src/common/parser.go
+++ b/src/common/parser.go
@@ -3,12 +3,13 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/opslevel/opslevel-go/v2023"
-	"github.com/opslevel/opslevel-jq-parser/v2023"
-	"github.com/opslevel/opslevel-k8s-controller/v2023"
-	"github.com/rs/zerolog/log"
 	"sync"
 	"time"
+
+	"github.com/opslevel/opslevel-go/v2023"
+	opslevel_jq_parser "github.com/opslevel/opslevel-jq-parser/v2023"
+	opslevel_k8s_controller "github.com/opslevel/opslevel-k8s-controller/v2023"
+	"github.com/rs/zerolog/log"
 )
 
 func AggregateServices(queue <-chan opslevel_jq_parser.ServiceRegistration) *[]opslevel_jq_parser.ServiceRegistration {
@@ -19,8 +20,8 @@ func AggregateServices(queue <-chan opslevel_jq_parser.ServiceRegistration) *[]o
 	return &services
 }
 
-func ReconcileServices(client *opslevel.Client, queue <-chan opslevel_jq_parser.ServiceRegistration) {
-	reconciler := NewServiceReconciler(NewOpslevelClient(client))
+func ReconcileServices(client *opslevel.Client, disableServiceCreation bool, queue <-chan opslevel_jq_parser.ServiceRegistration) {
+	reconciler := NewServiceReconciler(NewOpslevelClient(client), disableServiceCreation)
 	for registration := range queue {
 		err := reconciler.Reconcile(registration)
 		if err != nil {

--- a/src/common/reconciler.go
+++ b/src/common/reconciler.go
@@ -20,15 +20,15 @@ const (
 	serviceAliasesResult_APIErrorHappened      serviceAliasesResult = "APIErrorHappened"
 )
 
-var DisableServiceCreation = false
-
 type ServiceReconciler struct {
-	client *OpslevelClient
+	client                 *OpslevelClient
+	disableServiceCreation bool
 }
 
-func NewServiceReconciler(client *OpslevelClient) *ServiceReconciler {
+func NewServiceReconciler(client *OpslevelClient, disableServiceCreation bool) *ServiceReconciler {
 	return &ServiceReconciler{
-		client: client,
+		client:                 client,
+		disableServiceCreation: disableServiceCreation,
 	}
 }
 
@@ -139,7 +139,7 @@ func (r *ServiceReconciler) handleService(registration opslevel_jq_parser.Servic
 	service, status := r.lookupService(registration)
 	switch status {
 	case serviceAliasesResult_NoAliasesMatched:
-		if DisableServiceCreation {
+		if r.disableServiceCreation {
 			log.Info().Msgf("[%s] Avoided creating a new service\n\tREASON: service creation is disabled", registration.Name)
 			return nil, nil
 		}

--- a/src/common/reconciler.go
+++ b/src/common/reconciler.go
@@ -3,11 +3,12 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/opslevel/opslevel-go/v2023"
 	opslevel_jq_parser "github.com/opslevel/opslevel-jq-parser/v2023"
 	"github.com/rs/zerolog/log"
-	"strings"
 )
 
 type serviceAliasesResult string
@@ -177,13 +178,13 @@ func (r *ServiceReconciler) createService(registration opslevel_jq_parser.Servic
 	service, err := r.client.CreateService(serviceCreateInput)
 	if err != nil {
 		return service, fmt.Errorf("[%s] Failed creating service\n\tREASON: %v", registration.Name, err.Error())
-	} else {
+	} else if service.Id != "" {
 		log.Info().Msgf("[%s] Created new service", service.Name)
 	}
 	return service, err
 }
 
-func (r *ServiceReconciler) updateService(service *opslevel.Service, registration opslevel_jq_parser.ServiceRegistration, ) {
+func (r *ServiceReconciler) updateService(service *opslevel.Service, registration opslevel_jq_parser.ServiceRegistration) {
 	updateServiceInput := opslevel.ServiceUpdateInput{
 		Id:          service.Id,
 		Product:     registration.Product,
@@ -223,7 +224,7 @@ func (r *ServiceReconciler) updateService(service *opslevel.Service, registratio
 	}
 }
 
-func (r *ServiceReconciler) handleAliases(service *opslevel.Service, registration opslevel_jq_parser.ServiceRegistration, ) {
+func (r *ServiceReconciler) handleAliases(service *opslevel.Service, registration opslevel_jq_parser.ServiceRegistration) {
 	for _, alias := range registration.Aliases {
 		if alias == "" || service.HasAlias(alias) {
 			continue

--- a/src/common/reconciler.go
+++ b/src/common/reconciler.go
@@ -38,6 +38,9 @@ func (r *ServiceReconciler) Reconcile(registration opslevel_jq_parser.ServiceReg
 	if err != nil {
 		return err
 	}
+	if service == nil {
+		return nil
+	}
 
 	// We don't care about errors at this point because they will just be logged
 	r.handleAliases(service, registration)

--- a/src/common/reconciler.go
+++ b/src/common/reconciler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/opslevel/opslevel-go/v2023"
 	opslevel_jq_parser "github.com/opslevel/opslevel-jq-parser/v2023"
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/viper"
 )
 
 type serviceAliasesResult string
@@ -20,6 +19,8 @@ const (
 	serviceAliasesResult_MultipleServicesFound serviceAliasesResult = "MultipleServicesFound"
 	serviceAliasesResult_APIErrorHappened      serviceAliasesResult = "APIErrorHappened"
 )
+
+var DisableServiceCreation = false
 
 type ServiceReconciler struct {
 	client *OpslevelClient
@@ -138,7 +139,7 @@ func (r *ServiceReconciler) handleService(registration opslevel_jq_parser.Servic
 	service, status := r.lookupService(registration)
 	switch status {
 	case serviceAliasesResult_NoAliasesMatched:
-		if viper.GetBool("disable-service-create") {
+		if DisableServiceCreation {
 			log.Info().Msgf("[%s] Avoided creating a new service\n\tREASON: service creation is disabled", registration.Name)
 			return nil, nil
 		}

--- a/src/common/reconciler_test.go
+++ b/src/common/reconciler_test.go
@@ -2,11 +2,12 @@ package common_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/opslevel/kubectl-opslevel/common"
 	"github.com/opslevel/opslevel-go/v2023"
 	opslevel_jq_parser "github.com/opslevel/opslevel-jq-parser/v2023"
 	"github.com/rocktavious/autopilot/v2023"
-	"testing"
 )
 
 func TestReconcilerReconcile(t *testing.T) {
@@ -69,7 +70,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				Name:    "test",
 				Aliases: []string{},
 			},
-			reconciler: common.NewServiceReconciler(&common.OpslevelClient{}),
+			reconciler: common.NewServiceReconciler(&common.OpslevelClient{}, false),
 			assert: func(t *testing.T, err error) {
 				autopilot.Equals(t, "[test] found 0 aliases from kubernetes data", err.Error())
 			},
@@ -89,7 +90,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				GetRepositoryWithAliasHandler: func(alias string) (*opslevel.Repository, error) {
 					return nil, fmt.Errorf("api error")
 				},
-			}),
+			}, false),
 			assert: func(t *testing.T, err error) {
 				autopilot.Ok(t, err)
 			},
@@ -103,7 +104,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				GetServiceHandler: func(alias string) (*opslevel.Service, error) {
 					return nil, fmt.Errorf("api error")
 				},
-			}),
+			}, false),
 			assert: func(t *testing.T, err error) {
 				autopilot.Equals(t, "[test] api error during service lookup by alias.  unable to guarantee service was found or not ... skipping reconciliation", err.Error())
 			},
@@ -129,7 +130,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				CreateTagHandler: func(input opslevel.TagCreateInput) error {
 					panic("should not be called")
 				},
-			}),
+			}, false),
 			assert: func(t *testing.T, err error) {
 				autopilot.Ok(t, err)
 			},
@@ -167,7 +168,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				UpdateServiceRepositoryHandler: func(input opslevel.ServiceRepositoryUpdateInput) error {
 					panic("should not be called")
 				},
-			}),
+			}, false),
 			assert: func(t *testing.T, err error) {
 				autopilot.Ok(t, err)
 			},
@@ -187,7 +188,7 @@ func Test_Reconciler_ContainsAllTags(t *testing.T) {
 		tags   []opslevel.Tag
 		result bool
 	}
-	reconciler := common.NewServiceReconciler(&common.OpslevelClient{})
+	reconciler := common.NewServiceReconciler(&common.OpslevelClient{}, false)
 	cases := map[string]TestCase{
 		"Is True When All Tags Overlap": {
 			input: []opslevel.TagInput{
@@ -307,7 +308,7 @@ func Test_Reconciler_ServiceNeedsUpdate(t *testing.T) {
 			Alias: "tier_1",
 		},
 	}
-	reconciler := common.NewServiceReconciler(&common.OpslevelClient{})
+	reconciler := common.NewServiceReconciler(&common.OpslevelClient{}, false)
 	cases := map[string]TestCase{
 		"Is True When Input Differs 1": {
 			input: opslevel.ServiceUpdateInput{

--- a/src/common/reconciler_test.go
+++ b/src/common/reconciler_test.go
@@ -173,6 +173,44 @@ func TestReconcilerReconcile(t *testing.T) {
 				autopilot.Ok(t, err)
 			},
 		},
+		"Happy Path Do Not Create Services": {
+			registration: testRegistration,
+			reconciler: common.NewServiceReconciler(&common.OpslevelClient{
+				GetServiceHandler: func(alias string) (*opslevel.Service, error) {
+					return &opslevel.Service{}, nil // This returns a nil service as if the alias lookup didn't find anything
+				},
+				CreateServiceHandler: func(input opslevel.ServiceCreateInput) (*opslevel.Service, error) {
+					panic("should not be called")
+				},
+				UpdateServiceHandler: func(input opslevel.ServiceUpdateInput) (*opslevel.Service, error) {
+					panic("should not be called")
+				},
+				CreateAliasHandler: func(input opslevel.AliasCreateInput) error {
+					return nil
+				},
+				AssignTagsHandler: func(service *opslevel.Service, tags map[string]string) error {
+					return nil
+				},
+				CreateTagHandler: func(input opslevel.TagCreateInput) error {
+					return nil
+				},
+				CreateToolHandler: func(tool opslevel.ToolCreateInput) error {
+					return nil
+				},
+				GetRepositoryWithAliasHandler: func(alias string) (*opslevel.Repository, error) {
+					return nil, fmt.Errorf("api error")
+				},
+				CreateServiceRepositoryHandler: func(input opslevel.ServiceRepositoryCreateInput) error {
+					panic("should not be called")
+				},
+				UpdateServiceRepositoryHandler: func(input opslevel.ServiceRepositoryUpdateInput) error {
+					panic("should not be called")
+				},
+			}, true),
+			assert: func(t *testing.T, err error) {
+				autopilot.Ok(t, err)
+			},
+		},
 	}
 	// Act
 	autopilot.RunTableTests(t, cases, func(t *testing.T, test TestCase) {


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/kubectl-opslevel/issues/209

## Changelog

- [x] Add flag + env var for disabling service creation: `--disable-service-create`/`OPSLEVEL_DISABLE_SERVICE_CREATE`
- [x] Add an argument to the reconciler that prevents the creation of services. (This is necessary to avoid the `common` package from being reliant on the `cmd` package and `cobra`/`viper`.)
- [x] Add a test that ensures `OpslevelClient.CreateServiceHandler` is not called if creating services is disabled.
- [x] Make a `changie` entry

## Tophatting

Unit tests pass.
