### PR TITLE
use changie-action in changie-gen workflow

### DIFF
--- a/.github/workflows/changie-gen.yml
+++ b/.github/workflows/changie-gen.yml
@@ -1,33 +1,56 @@
 name: Changie Gen
 
 on:
-  pull_request:
-    # catch when the PR is opened with the label or when the label is added
-    types: [labeled]
-
-permissions:
-  contents: write
-  pull-requests: read
+  workflow_run:
+    workflows: [Dependabot Labels]
+    types:
+      - completed
 
 jobs:
-  generate_changelog:
-    strategy:
-      matrix:
-        include:
-          - label: "dependencies"
-            changie_kind: "Dependency"
+  generate-changelog:
+    env:
+      MAIN_BRANCH: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
+      PR_BRANCH: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
     runs-on: ubuntu-latest
-
+    # NOTE: "github.event.workflow_run.conclusion" check needed within "steps"
     steps:
-
-    - name: Create and commit changelog on bot PR
-      if: ${{ contains(github.event.pull_request.labels.*.name, matrix.label) }}
-      id: bot_changelog
-      uses: emmyoop/changie_bot@v1.1.0
+    - name: Checkout branch that Dependabot labeled
+      if: github.event.workflow_run.conclusion == 'success'
+      uses: actions/checkout@v4
       with:
-        GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
-        commit_author_name: "Github Build Bot"
-        commit_author_email: "<bots@opslevel.com>"
-        commit_message: "Add automated changelog yaml from template for bot PR"
-        changie_kind: ${{ matrix.changie_kind }}
-        label: ${{ matrix.label }}
+        ref: ${{ env.PR_BRANCH }}
+        token: ${{ secrets.ORG_GITHUB_TOKEN }}
+
+    - name: Check if changelog file exists already
+      if: github.event.workflow_run.conclusion == 'success'
+      shell: bash
+      id: changelog_check
+      run: |
+        git fetch origin ${{ env.MAIN_BRANCH }}
+        if [[ -n $(git diff --name-only main -- .changes/unreleased/*.yaml) ]]; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+          echo "Changelog already exists for this PR, skip creating a new one"
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+          echo "No changelog exists for this PR, creating a new one"
+        fi
+
+    - name: Create changie log
+      if: >-
+        github.event.workflow_run.conclusion == 'success' &&
+        steps.changelog_check.outputs.exists == 'false'
+      uses: miniscruff/changie-action@v2
+      with:
+        version: latest
+        args: new --kind Feature --body "${{ github.event.workflow_run.display_title }}"
+
+    - name: Commit & Push changes
+      if: github.event.workflow_run.conclusion == 'success' && steps.changelog_check.outputs.exists == 'false'
+      shell: bash
+      run: |
+        git config user.name "OpsLevel Bots"
+        git config user.email "bots@opslevel.com"
+        git pull
+        git add .
+        git commit -m "Add automated changelog yaml from template"
+        git push

--- a/.github/workflows/dependabot-labels.yml
+++ b/.github/workflows/dependabot-labels.yml
@@ -1,0 +1,12 @@
+name: Dependabot Labels
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  dependabot-pr-label:
+    if: github.event.label.name == 'dependencies'
+    uses: OpsLevel/actions/.github/workflows/dependabot_pr_labels.yml@main
+


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->
Identical changes to [this cli PR](https://github.com/OpsLevel/cli/pull/210). Also, [this PR](https://github.com/OpsLevel/cli/pull/227) showcases the auto-changie generating workflow

## Changelog

Use [reusable workflow from our actions repo](https://github.com/OpsLevel/actions/blob/main/.github/workflows/dependabot_pr_labels.yml) to trigger adding a changelog to Dependabot PRs with changie.

Note: the job in this workflow runs only if dependabot opens a PR.

- [X] List your changes here
- [ ] Make a `changie` entry, N/A CI only

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
