### PR TITLE
continue - upload config file with yaml, not viper

### DIFF
--- a/.changes/unreleased/Bugfix-20240105-163122.yaml
+++ b/.changes/unreleased/Bugfix-20240105-163122.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix bug where user could not generate config unless they had one already
+time: 2024-01-05T16:31:22.391384-05:00

--- a/.changes/unreleased/Bugfix-20240105-163302.yaml
+++ b/.changes/unreleased/Bugfix-20240105-163302.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: '--config .' will now correctly read from ./opslevel-k8s.yaml and '--config -' will read from stdin
+time: 2024-01-05T16:33:02.994594-05:00

--- a/.changes/unreleased/Feature-20231220-154838.yaml
+++ b/.changes/unreleased/Feature-20231220-154838.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: upload config file with yaml, not viper
+time: 2023-12-20T15:48:38.852866-06:00

--- a/.changes/unreleased/Feature-20231220-154838.yaml
+++ b/.changes/unreleased/Feature-20231220-154838.yaml
@@ -1,3 +1,0 @@
-kind: Feature
-body: upload config file with yaml, not viper
-time: 2023-12-20T15:48:38.852866-06:00

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ src/dist
 .DS_Store
 **/coverage.txt
 **/go.work*
+**/opslevel-k8s.yaml

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -10,6 +10,7 @@ import (
 	yaml "gopkg.in/yaml.v3"
 
 	"github.com/alecthomas/jsonschema"
+	"github.com/creasty/defaults"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -83,6 +84,9 @@ func LoadConfig() (*common.Config, error) {
 
 	if commonConfig.Version != common.ConfigCurrentVersion {
 		return nil, fmt.Errorf("supported config version is '%s' but found '%s' | Please update config file or create a new sample with `kubectl opslevel config sample`", common.ConfigCurrentVersion, commonConfig.Version)
+	}
+	if err := defaults.Set(&commonConfig); err != nil {
+		return nil, err
 	}
 
 	return &commonConfig, nil

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/opslevel/kubectl-opslevel/common"
 
@@ -72,22 +71,16 @@ func init() {
 }
 
 func LoadConfig() (*common.Config, error) {
-	var commonConfig common.Config
-
-	yamlData, err := os.ReadFile(cfgFile)
-	if err != nil {
+	v := common.Config{}
+	if err := viper.Unmarshal(&v); err != nil {
 		return nil, err
 	}
-	if err := yaml.Unmarshal(yamlData, &commonConfig); err != nil {
-		return nil, err
+	if v.Version != common.ConfigCurrentVersion {
+		return nil, fmt.Errorf("supported config version is '%s' but found '%s' | Please update config file or create a new sample with `kubectl opslevel config sample`", common.ConfigCurrentVersion, v.Version)
 	}
 
-	if commonConfig.Version != common.ConfigCurrentVersion {
-		return nil, fmt.Errorf("supported config version is '%s' but found '%s' | Please update config file or create a new sample with `kubectl opslevel config sample`", common.ConfigCurrentVersion, commonConfig.Version)
-	}
-	if err := defaults.Set(&commonConfig); err != nil {
+	if err := defaults.Set(&v); err != nil {
 		return nil, err
 	}
-
-	return &commonConfig, nil
+	return &v, nil
 }

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
-	"github.com/creasty/defaults"
 	"github.com/opslevel/kubectl-opslevel/common"
 
 	yaml "gopkg.in/yaml.v3"
@@ -71,20 +71,19 @@ func init() {
 }
 
 func LoadConfig() (*common.Config, error) {
-	v := common.ConfigVersion{}
-	if err := viper.Unmarshal(&v); err != nil {
+	var commonConfig common.Config
+
+	yamlData, err := os.ReadFile(cfgFile)
+	if err != nil {
 		return nil, err
 	}
-	if v.Version != common.ConfigCurrentVersion {
-		return nil, fmt.Errorf("supported config version is '%s' but found '%s' | Please update config file or create a new sample with `kubectl opslevel config sample`", common.ConfigCurrentVersion, v.Version)
+	if err := yaml.Unmarshal(yamlData, &commonConfig); err != nil {
+		return nil, err
 	}
 
-	c := common.Config{}
-	if err := viper.Unmarshal(&c); err != nil {
-		return nil, err
+	if commonConfig.Version != common.ConfigCurrentVersion {
+		return nil, fmt.Errorf("supported config version is '%s' but found '%s' | Please update config file or create a new sample with `kubectl opslevel config sample`", common.ConfigCurrentVersion, commonConfig.Version)
 	}
-	if err := defaults.Set(&c); err != nil {
-		return nil, err
-	}
-	return &c, nil
+
+	return &commonConfig, nil
 }

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -1,15 +1,16 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/opslevel/kubectl-opslevel/common"
 
 	yaml "gopkg.in/yaml.v3"
 
 	"github.com/alecthomas/jsonschema"
-	"github.com/creasty/defaults"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -51,11 +52,13 @@ var configSampleCmd = &cobra.Command{
 	Long:  "Print a sample config file which could be used",
 	Run: func(cmd *cobra.Command, args []string) {
 		var cfg *common.Config
+		var err error
 		if viper.GetBool("simple") {
-			cfg, _ = common.GetConfig(common.ConfigSimple)
+			cfg, err = common.ParseConfig(common.ConfigSimple)
 		} else {
-			cfg, _ = common.GetConfig(common.ConfigSample)
+			cfg, err = common.ParseConfig(common.ConfigSample)
 		}
+		cobra.CheckErr(err)
 		output, err := yaml.Marshal(cfg)
 		cobra.CheckErr(err)
 		fmt.Println(string(output))
@@ -70,17 +73,34 @@ func init() {
 	viper.BindPFlags(configSampleCmd.Flags())
 }
 
-func LoadConfig() (*common.Config, error) {
-	v := common.Config{}
-	if err := viper.Unmarshal(&v); err != nil {
-		return nil, err
-	}
-	if v.Version != common.ConfigCurrentVersion {
-		return nil, fmt.Errorf("supported config version is '%s' but found '%s' | Please update config file or create a new sample with `kubectl opslevel config sample`", common.ConfigCurrentVersion, v.Version)
-	}
+func readConfig() []byte {
+	var err error
+	var res []byte
 
-	if err := defaults.Set(&v); err != nil {
+	switch cfgFile {
+	case ".":
+		res, err = os.ReadFile("./opslevel-k8s.yaml")
+	case "-":
+		buf := bytes.Buffer{}
+		_, err = buf.ReadFrom(os.Stdin)
+		res = buf.Bytes()
+	default:
+		res, err = os.ReadFile(cfgFile)
+	}
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+func LoadConfig() (*common.Config, error) {
+	configBytes := readConfig()
+	config, err := common.ParseConfig(string(configBytes))
+	if err != nil {
 		return nil, err
 	}
-	return &v, nil
+	if config.Version != common.ConfigCurrentVersion {
+		return nil, fmt.Errorf("supported config version is '%s' but found '%s' | Please update config file or create a new sample with `kubectl opslevel config sample`", common.ConfigCurrentVersion, config.Version)
+	}
+	return config, nil
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -63,6 +63,7 @@ func init() {
 	viper.BindEnv("workers", "OPSLEVEL_WORKERS", "OL_WORKERS")
 	viper.BindEnv("disable-service-create", "OPSLEVEL_DISABLE_SERVICE_CREATE", "OL_DISABLE_SERVICE_CREATE")
 	cobra.OnInitialize(func() {
+		readConfig()
 		setupLogging()
 		setupOutput()
 		setupConcurrency()
@@ -72,6 +73,29 @@ func init() {
 			log.Info().Msgf("Service creation is disabled.")
 		}
 	})
+}
+
+func readConfig() {
+	if cfgFile != "" {
+		if cfgFile == "-" {
+			viper.SetConfigType("yaml")
+			viper.ReadConfig(os.Stdin)
+			return
+		} else {
+			viper.SetConfigFile(cfgFile)
+		}
+	} else {
+		home, err := os.UserHomeDir()
+		cobra.CheckErr(err)
+
+		viper.SetConfigName("opslevel")
+		viper.SetConfigType("yaml")
+		viper.AddConfigPath(".")
+		viper.AddConfigPath(home)
+	}
+	viper.SetEnvPrefix("OPSLEVEL")
+	viper.AutomaticEnv()
+	viper.ReadInConfig()
 }
 
 func setupLogging() {

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -76,26 +76,21 @@ func init() {
 }
 
 func readConfig() {
-	if cfgFile != "" {
-		if cfgFile == "-" {
-			viper.SetConfigType("yaml")
-			viper.ReadConfig(os.Stdin)
-			return
-		} else {
-			viper.SetConfigFile(cfgFile)
-		}
-	} else {
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-
-		viper.SetConfigName("opslevel")
-		viper.SetConfigType("yaml")
-		viper.AddConfigPath(".")
-		viper.AddConfigPath(home)
+	viper.SetConfigType("yaml")
+	switch cfgFile {
+	case ".":
+		viper.SetConfigFile("./opslevel-k8s.yaml")
+	case "-":
+		viper.ReadConfig(os.Stdin)
+	default:
+		viper.SetConfigFile(cfgFile)
 	}
 	viper.SetEnvPrefix("OPSLEVEL")
 	viper.AutomaticEnv()
-	viper.ReadInConfig()
+	err := viper.ReadInConfig()
+	if err != nil {
+		panic(err)
+	}
 }
 
 func setupLogging() {

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -63,7 +63,6 @@ func init() {
 	viper.BindEnv("workers", "OPSLEVEL_WORKERS", "OL_WORKERS")
 	viper.BindEnv("disable-service-create", "OPSLEVEL_DISABLE_SERVICE_CREATE", "OL_DISABLE_SERVICE_CREATE")
 	cobra.OnInitialize(func() {
-		readConfig()
 		setupLogging()
 		setupOutput()
 		setupConcurrency()
@@ -73,32 +72,6 @@ func init() {
 			log.Info().Msgf("Service creation is disabled.")
 		}
 	})
-}
-
-func readConfig() {
-	if cfgFile != "" {
-		if cfgFile == "." {
-			viper.SetConfigType("yaml")
-			viper.ReadConfig(os.Stdin)
-			return
-		} else {
-			viper.SetConfigFile(cfgFile)
-		}
-	} else {
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-
-		viper.SetConfigName("opslevel")
-		viper.SetConfigType("yaml")
-		viper.AddConfigPath(".")
-		viper.AddConfigPath(home)
-	}
-	viper.SetEnvPrefix("OPSLEVEL")
-	viper.AutomaticEnv()
-	err := viper.ReadInConfig()
-	if err != nil {
-		panic(err)
-	}
 }
 
 func setupLogging() {

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -63,7 +63,7 @@ func init() {
 	viper.BindEnv("workers", "OPSLEVEL_WORKERS", "OL_WORKERS")
 	viper.BindEnv("disable-service-create", "OPSLEVEL_DISABLE_SERVICE_CREATE", "OL_DISABLE_SERVICE_CREATE")
 	cobra.OnInitialize(func() {
-		readConfig()
+		setupEnv()
 		setupLogging()
 		setupOutput()
 		setupConcurrency()
@@ -75,22 +75,9 @@ func init() {
 	})
 }
 
-func readConfig() {
-	viper.SetConfigType("yaml")
-	switch cfgFile {
-	case ".":
-		viper.SetConfigFile("./opslevel-k8s.yaml")
-	case "-":
-		viper.ReadConfig(os.Stdin)
-	default:
-		viper.SetConfigFile(cfgFile)
-	}
+func setupEnv() {
 	viper.SetEnvPrefix("OPSLEVEL")
 	viper.AutomaticEnv()
-	err := viper.ReadInConfig()
-	if err != nil {
-		panic(err)
-	}
 }
 
 func setupLogging() {

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"github.com/creasty/defaults"
 	opslevel_jq_parser "github.com/opslevel/opslevel-jq-parser/v2023"
 	opslevel_k8s_controller "github.com/opslevel/opslevel-k8s-controller/v2023"
 	"gopkg.in/yaml.v3"
@@ -110,8 +111,13 @@ service:
           - .metadata.annotations."opslevel.com/ignore"
 `
 
-func GetConfig(data string) (*Config, error) {
+func ParseConfig(data string) (*Config, error) {
 	var output Config
-	err := yaml.Unmarshal([]byte(data), &output)
-	return &output, err
+	if err := yaml.Unmarshal([]byte(data), &output); err != nil {
+		return nil, err
+	}
+	if err := defaults.Set(&output); err != nil {
+		return nil, err
+	}
+	return &output, nil
 }

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -25,10 +25,6 @@ type Config struct {
 	Service Service `json:"service"`
 }
 
-type ConfigVersion struct {
-	Version string `json:"version" yaml:"version"`
-}
-
 var ConfigCurrentVersion = "1.2.0"
 
 // Make sure we only use spaces inside of these samples

--- a/src/common/config_test.go
+++ b/src/common/config_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/rocktavious/autopilot/v2023"
 )
 
-func TestGetConfig(t *testing.T) {
-	simple, err := common.GetConfig(common.ConfigSimple)
+func TestParseConfig(t *testing.T) {
+	simple, err := common.ParseConfig(common.ConfigSimple)
 	autopilot.Ok(t, err)
-	sample, err := common.GetConfig(common.ConfigSample)
+	sample, err := common.ParseConfig(common.ConfigSample)
 	autopilot.Ok(t, err)
 
 	autopilot.Equals(t, ".metadata.namespace", simple.Service.Import[0].OpslevelConfig.Owner)


### PR DESCRIPTION
## Issues

Continues the bugfixes in https://github.com/OpsLevel/kubectl-opslevel/pull/222

## Changelog

- [x] Rename `GetConfig` to `ParseConfig` in `common`, use that function to read yaml config files
- [x] Separate setup env and read config logic, read config only when needed
- [x] Make `readConfig` easier to read AND stop using viper to read yaml
- [x] Make a `changie` entry

## Tophatting

Before - had bug where we can't even generate the file if we don't have one. 

```
$ go run main.go service preview
panic: open ./opslevel-k8s.yaml: no such file or directory
$ go run main.go config sample
panic: open ./opslevel-k8s.yaml: no such file or directory
```

Now, we can get generate the file without getting stuck. I tested that `service preview` works. 

```
$ go run main.go config sample simple > $HOME/kuber.yaml
$ go run main.go service preview --config $HOME/kuber.yaml
$ go run main.go service preview # reads from ./opslevel-k8s.yaml
```