### PR TITLE
Fix tools not being deduplicated | Fix bug where tools logging causes nil pointer exception

### DIFF
--- a/.changes/unreleased/Bugfix-20240113-031926.yaml
+++ b/.changes/unreleased/Bugfix-20240113-031926.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix bug where the same tool would be created multiple times in a single run
+time: 2024-01-13T03:19:26.521152-05:00

--- a/.changes/unreleased/Bugfix-20240118-095350.yaml
+++ b/.changes/unreleased/Bugfix-20240118-095350.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix bug where logging tools would cause nil pointer exceptions
+time: 2024-01-18T09:53:50.81081-05:00

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ src/dist
 .DS_Store
 **/coverage.txt
 **/go.work*
+**/opslevel-k8s.yaml
 src/*.yaml
 **/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ src/dist
 **/coverage.txt
 **/go.work*
 **/opslevel-k8s.yaml
-src/*.yaml
-**/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ src/dist
 .DS_Store
 **/coverage.txt
 **/go.work*
-**/opslevel-k8s.yaml
+**/*.yaml
+**/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ src/dist
 .DS_Store
 **/coverage.txt
 **/go.work*
-**/*.yaml
+src/*.yaml
 **/.vscode

--- a/src/common/reconciler.go
+++ b/src/common/reconciler.go
@@ -293,7 +293,23 @@ func (r *ServiceReconciler) handleCreateTags(service *opslevel.Service, registra
 }
 
 func (r *ServiceReconciler) handleTools(service *opslevel.Service, registration opslevel_jq_parser.ServiceRegistration) {
+	var set = map[string]struct{}{} // necessary for deduplication of tools created
 	for _, tool := range registration.Tools {
+		var (
+			toolEnv string
+			key     string
+			ok      bool
+		)
+		if tool.Environment != nil {
+			toolEnv = *tool.Environment
+		}
+		key = string(tool.Category) + string(tool.DisplayName) + string(toolEnv)
+		if _, ok = set[key]; ok {
+			log.Debug().Msgf("[%s] Tool '{Category: %s, Environment: %s, Name: %s}' this is a duplicate entry ... skipping", service.Name, tool.Category, *tool.Environment, tool.DisplayName)
+			continue
+		}
+		set[key] = struct{}{}
+
 		if service.HasTool(tool.Category, tool.DisplayName, *tool.Environment) {
 			log.Debug().Msgf("[%s] Tool '{Category: %s, Environment: %s, Name: %s}' already exists on service ... skipping", service.Name, tool.Category, *tool.Environment, tool.DisplayName)
 			continue

--- a/src/common/reconciler.go
+++ b/src/common/reconciler.go
@@ -295,16 +295,21 @@ func (r *ServiceReconciler) handleCreateTags(service *opslevel.Service, registra
 func (r *ServiceReconciler) handleTools(service *opslevel.Service, registration opslevel_jq_parser.ServiceRegistration) {
 	deduplicated := opslevel_jq_parser.DeduplicatedTools(registration.Tools)
 	for _, tool := range deduplicated {
-		if service.HasTool(tool.Category, tool.DisplayName, *tool.Environment) {
-			log.Debug().Msgf("[%s] Tool '{Category: %s, Environment: %s, Name: %s}' already exists on service ... skipping", service.Name, tool.Category, *tool.Environment, tool.DisplayName)
+		toolEnv := ""
+		if tool.Environment != nil {
+			toolEnv = *tool.Environment
+		}
+
+		if service.HasTool(tool.Category, tool.DisplayName, toolEnv) {
+			log.Debug().Msgf("[%s] Tool '{Category: %s, Environment: %s, Name: %s}' already exists on service ... skipping", service.Name, tool.Category, toolEnv, tool.DisplayName)
 			continue
 		}
 		tool.ServiceId = &service.Id
 		err := r.client.CreateTool(tool)
 		if err != nil {
-			log.Error().Msgf("[%s] Failed assigning tool '{Category: %s, Environment: %s, Name: %s}'\n\tREASON: %v", service.Name, tool.Category, *tool.Environment, tool.DisplayName, err.Error())
+			log.Error().Msgf("[%s] Failed assigning tool '{Category: %s, Environment: %s, Name: %s}'\n\tREASON: %v", service.Name, tool.Category, toolEnv, tool.DisplayName, err.Error())
 		} else {
-			log.Info().Msgf("[%s] Ensured tool '{Category: %s, Environment: %s, Name: %s}'", service.Name, tool.Category, *tool.Environment, tool.DisplayName)
+			log.Info().Msgf("[%s] Ensured tool '{Category: %s, Environment: %s, Name: %s}'", service.Name, tool.Category, toolEnv, tool.DisplayName)
 		}
 	}
 }

--- a/src/common/reconciler.go
+++ b/src/common/reconciler.go
@@ -293,23 +293,8 @@ func (r *ServiceReconciler) handleCreateTags(service *opslevel.Service, registra
 }
 
 func (r *ServiceReconciler) handleTools(service *opslevel.Service, registration opslevel_jq_parser.ServiceRegistration) {
-	set := make(map[string]struct{}) // necessary for deduplication of tools created
-	for _, tool := range registration.Tools {
-		var (
-			toolEnv string
-			key     string
-			ok      bool
-		)
-		if tool.Environment != nil {
-			toolEnv = *tool.Environment
-		}
-		key = string(tool.Category) + string(tool.DisplayName) + string(toolEnv)
-		if _, ok = set[key]; ok {
-			log.Debug().Msgf("[%s] Tool '{Category: %s, Environment: %s, Name: %s}' this is a duplicate entry ... skipping", service.Name, tool.Category, *tool.Environment, tool.DisplayName)
-			continue
-		}
-		set[key] = struct{}{}
-
+	deduplicated := opslevel_jq_parser.DeduplicatedTools(registration.Tools)
+	for _, tool := range deduplicated {
 		if service.HasTool(tool.Category, tool.DisplayName, *tool.Environment) {
 			log.Debug().Msgf("[%s] Tool '{Category: %s, Environment: %s, Name: %s}' already exists on service ... skipping", service.Name, tool.Category, *tool.Environment, tool.DisplayName)
 			continue

--- a/src/common/reconciler.go
+++ b/src/common/reconciler.go
@@ -293,7 +293,7 @@ func (r *ServiceReconciler) handleCreateTags(service *opslevel.Service, registra
 }
 
 func (r *ServiceReconciler) handleTools(service *opslevel.Service, registration opslevel_jq_parser.ServiceRegistration) {
-	set := map[string]struct{}{} // necessary for deduplication of tools created
+	set := make(map[string]struct{}) // necessary for deduplication of tools created
 	for _, tool := range registration.Tools {
 		var (
 			toolEnv string

--- a/src/common/reconciler.go
+++ b/src/common/reconciler.go
@@ -293,13 +293,11 @@ func (r *ServiceReconciler) handleCreateTags(service *opslevel.Service, registra
 }
 
 func (r *ServiceReconciler) handleTools(service *opslevel.Service, registration opslevel_jq_parser.ServiceRegistration) {
-	deduplicated := opslevel_jq_parser.DeduplicatedTools(registration.Tools)
-	for _, tool := range deduplicated {
+	for _, tool := range registration.Tools {
 		toolEnv := ""
 		if tool.Environment != nil {
 			toolEnv = *tool.Environment
 		}
-
 		if service.HasTool(tool.Category, tool.DisplayName, toolEnv) {
 			log.Debug().Msgf("[%s] Tool '{Category: %s, Environment: %s, Name: %s}' already exists on service ... skipping", service.Name, tool.Category, toolEnv, tool.DisplayName)
 			continue

--- a/src/common/reconciler.go
+++ b/src/common/reconciler.go
@@ -293,7 +293,7 @@ func (r *ServiceReconciler) handleCreateTags(service *opslevel.Service, registra
 }
 
 func (r *ServiceReconciler) handleTools(service *opslevel.Service, registration opslevel_jq_parser.ServiceRegistration) {
-	var set = map[string]struct{}{} // necessary for deduplication of tools created
+	set := map[string]struct{}{} // necessary for deduplication of tools created
 	for _, tool := range registration.Tools {
 		var (
 			toolEnv string

--- a/src/common/reconciler_test.go
+++ b/src/common/reconciler_test.go
@@ -409,7 +409,7 @@ func Test_Reconciler_HandleTools(t *testing.T) {
 	var (
 		err      error
 		newTools = func(names ...string) []opslevel.Tool {
-			var tools = make([]opslevel.Tool, len(names))
+			tools := make([]opslevel.Tool, len(names))
 			for i, d := range names {
 				tools[i] = opslevel.Tool{
 					Category:    opslevel.ToolCategoryCode,
@@ -420,7 +420,7 @@ func Test_Reconciler_HandleTools(t *testing.T) {
 			return tools
 		}
 		newToolInputs = func(names ...string) []opslevel.ToolCreateInput {
-			var inputs = make([]opslevel.ToolCreateInput, len(names))
+			inputs := make([]opslevel.ToolCreateInput, len(names))
 			for i, d := range names {
 				inputs[i] = opslevel.ToolCreateInput{
 					Category:    opslevel.ToolCategoryCode,

--- a/src/common/reconciler_test.go
+++ b/src/common/reconciler_test.go
@@ -408,7 +408,7 @@ func Test_Reconciler_HandleTools(t *testing.T) {
 	// Arrange
 	registration := opslevel_jq_parser.ServiceRegistration{
 		Aliases: []string{"a_test_service"},
-		Tools:   newToolInputs("A", "B", "C", "D", "E", "F", "G", "F", "G", "F", "G", "F", "G"),
+		Tools:   newToolInputs("A", "B", "C", "D", "E", "F", "G"),
 	}
 	service := opslevel.Service{
 		ServiceId: opslevel.ServiceId{

--- a/src/common/reconciler_test.go
+++ b/src/common/reconciler_test.go
@@ -406,58 +406,57 @@ func Test_Reconciler_ServiceNeedsUpdate(t *testing.T) {
 
 func Test_Reconciler_HandleTools(t *testing.T) {
 	// Arrange
-	var (
-		err      error
-		newTools = func(names ...string) []opslevel.Tool {
-			tools := make([]opslevel.Tool, len(names))
-			for i, d := range names {
-				tools[i] = opslevel.Tool{
-					Category:    opslevel.ToolCategoryCode,
-					DisplayName: d,
-					Environment: "XXX",
-				}
-			}
-			return tools
-		}
-		newToolInputs = func(names ...string) []opslevel.ToolCreateInput {
-			inputs := make([]opslevel.ToolCreateInput, len(names))
-			for i, d := range names {
-				inputs[i] = opslevel.ToolCreateInput{
-					Category:    opslevel.ToolCategoryCode,
-					DisplayName: d,
-					Environment: opslevel.RefOf("XXX"),
-				}
-			}
-			return inputs
-		}
-		registration = opslevel_jq_parser.ServiceRegistration{
-			Aliases: []string{"a_test_service"},
-			Tools:   newToolInputs("A", "B", "C", "D", "E", "F", "G", "F", "G", "F", "G", "F", "G"),
-		}
-		service = opslevel.Service{
-			ServiceId: opslevel.ServiceId{
-				Id: opslevel.ID("XXX"),
-			},
-			Name: "ATestService",
-			Tools: &opslevel.ToolConnection{
-				Nodes: newTools("A", "B", "C", "D", "E"),
-			},
-		}
-		toolsCreated = []opslevel.ToolCreateInput{}
-		reconciler   = common.NewServiceReconciler(&common.OpslevelClient{
-			GetServiceHandler: func(alias string) (*opslevel.Service, error) {
-				return &service, nil
-			},
-			CreateToolHandler: func(tool opslevel.ToolCreateInput) error {
-				toolsCreated = append(toolsCreated, tool)
-				return nil
-			},
-		}, false)
-	)
+	registration := opslevel_jq_parser.ServiceRegistration{
+		Aliases: []string{"a_test_service"},
+		Tools:   newToolInputs("A", "B", "C", "D", "E", "F", "G", "F", "G", "F", "G", "F", "G"),
+	}
+	service := opslevel.Service{
+		ServiceId: opslevel.ServiceId{
+			Id: opslevel.ID("XXX"),
+		},
+		Name: "ATestService",
+		Tools: &opslevel.ToolConnection{
+			Nodes: newTools("A", "B", "C", "D", "E"),
+		},
+	}
+	toolsCreated := []opslevel.ToolCreateInput{}
+	reconciler := common.NewServiceReconciler(&common.OpslevelClient{
+		GetServiceHandler: func(alias string) (*opslevel.Service, error) {
+			return &service, nil
+		},
+		CreateToolHandler: func(tool opslevel.ToolCreateInput) error {
+			toolsCreated = append(toolsCreated, tool)
+			return nil
+		},
+	}, false)
 	// Act
-	err = reconciler.Reconcile(registration)
+	err := reconciler.Reconcile(registration)
 	autopilot.Ok(t, err)
 	// Assert
 	autopilot.Assert(t, len(toolsCreated) == 2 && toolsCreated[0].DisplayName == "F" &&
 		toolsCreated[1].DisplayName == "G", "expected tools created to be ['F','G']")
+}
+
+func newToolInputs(names ...string) []opslevel.ToolCreateInput {
+	inputs := make([]opslevel.ToolCreateInput, len(names))
+	for i, d := range names {
+		inputs[i] = opslevel.ToolCreateInput{
+			Category:    opslevel.ToolCategoryCode,
+			DisplayName: d,
+			Environment: opslevel.RefOf("XXX"),
+		}
+	}
+	return inputs
+}
+
+func newTools(names ...string) []opslevel.Tool {
+	tools := make([]opslevel.Tool, len(names))
+	for i, d := range names {
+		tools[i] = opslevel.Tool{
+			Category:    opslevel.ToolCategoryCode,
+			DisplayName: d,
+			Environment: "XXX",
+		}
+	}
+	return tools
 }


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/kubectl-opslevel/issues/210

https://github.com/OpsLevel/opslevel-jq-parser/pull/14 and https://github.com/OpsLevel/opslevel-jq-parser/pull/15

## Changelog

- [x] Add a unit test that covers all cases
- [x] Make a `changie` entry
- [x] Added a a nil check for `*tool.Environment`. A customer reported this was crashing for them. 