### PR TITLE
Add support for SIGINT, SIGTERM with Context

### DIFF
--- a/.changes/unreleased/Docs-20240117-193749.yaml
+++ b/.changes/unreleased/Docs-20240117-193749.yaml
@@ -1,0 +1,3 @@
+kind: Docs
+body: Add local testing instructions under docs/
+time: 2024-01-17T19:37:49.237491-05:00

--- a/.changes/unreleased/Feature-20240117-143424.yaml
+++ b/.changes/unreleased/Feature-20240117-143424.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add support for clean exit on SIGINT/SIGTERM
+time: 2024-01-17T14:34:24.999559-05:00

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing
+
+1. [Local installation | Local development](./docs/Local-Development.md)
+

--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,8 @@
 <p align="center">
  <a href="#prerequisite">Prerequisite</a> |
  <a href="#installation">Installation</a> |
+ <a href="./src/CONTRIBUTING.md">CONTRIBUTING</a> |
+ <a href="./src/docs/Local-Development.md">Local Dev/Testing Instructions</a> |
  <a href="#quickstart">Quickstart</a> |
  <a href="https://docs.opslevel.com/docs/kubernetes-integration">Documentation</a> |
  <a href="#troubleshooting">Troubleshooting</a>
@@ -38,6 +40,7 @@
 ## Installation
 
 ```sh
+# OR - manually copy the binary to /usr/bin/local
 brew install opslevel/tap/kubectl
 ```
 

--- a/docs/Local-Development.md
+++ b/docs/Local-Development.md
@@ -1,0 +1,164 @@
+# Local development
+
+1. [First steps | Local installation](#first-steps)
+1. [Setup testing env](#setup-testing-env)
+1. [Test commands locally](#test-commands-locally)
+1. [Cleanup](#cleanup)
+
+## First Steps
+
+**Get an OpsLevel API token for a dev environment.** Do not use your prod environment since this involves mutating lots of services in OpsLevel.
+
+Install these:
+
+1. [minikube](https://minikube.sigs.k8s.io/docs/start/)  - this is a suggestion, you can also use **your own dev cluster if you have one.** Other options include [kind](https://kind.sigs.k8s.io/) or [k3s](https://k3s.io/).
+1. [task](https://taskfile.dev/) - this will install dependencies for you.
+1. [OpsLevel CLI](https://github.com/OpsLevel/cli) - makes things way easier.
+
+```
+brew install minikube
+brew install task
+brew install opslevel/tap/cli
+```
+
+Then run:
+
+```
+task setup
+cd src                       # from now on this tutorial is going to assume you're in the src/ directory.
+go build .
+./kubectl-opslevel           # you can also use `go run main.go` or set an alias like `alias ko='./kubectl-opslevel'`
+                             # and `alias bko='go build . && ./kubectl-opslevel'`
+```
+
+
+> [!TIP]
+> Your local version can only be called using `./kubectl-opslevel`. That is NOT THE SAME as `kubectl opslevel` which is the actual kubectl plugin you have installed. You can see what that is exactly by doing `kubectl plugin list`. You can install your local build of the plugin by copying it to /usr/local/bin and UNINSTALLING the version you have installed already (if any).
+
+## Setup testing env
+
+```
+minikube start
+```
+
+> [!CAUTION]
+> Beyond this step, make sure your kubectl is set to your minikube cluster AND that your `OPSLEVEL_API_TOKEN` is for a dev environment.
+
+Next add some pods resources for testing and add a config file. You can use whatever resources and config you'd like, there are some examples provided in this folder.
+
+```
+kubectl apply -f ../docs/example-pod.yaml
+cp ../docs/example-opslevel-k8s.yaml .
+```
+
+You can find even more examples of config files by doing `./kubectl-opslevel config sample -h`.
+
+## Test commands locally
+
+**Service Preview**
+
+You can test `./kubectl-opslevel service preview` at any time by just running the command. 
+
+Make sure the service count matches up with what you expect and that the service fields and tags are being read correctly.
+
+```
+7:01PM INF [/v1/pods] Informer is ready and synced
+The following data was found in your Kubernetes cluster ...
+
+[
+    {
+        "Name": "random-nginx-1",
+        "Description": "stack was not necessary - rolled back",
+        "Owner": "platform",
+        "Aliases": [
+            "default-random-nginx-1"
+        ],
+        "TagAssigns": [
+            {
+                "key": "k8s_created",
+                "value": "2024-01-16T03:05:51Z"
+            },
+            {
+                "key": "hello",
+                "value": "world"
+            },
+```
+
+**Service Import**
+
+Use `kubectl edit pod/random-nginx-2` and change some fields and tags. Then import your changes with `./kubectl-opslevel service import`.
+
+Import should loop only once and stop just like preview except it will actually update/create data in OpsLevel.
+
+```
+7:21PM INF [/v1/pods] Informer is ready and synced
+7:21PM INF [random-nginx-1] No changes detected to fields - skipping update
+7:21PM INF [random-nginx-1] All tags already assigned to service.
+7:21PM INF [random-nginx-2] Updated Service - Diff:
+  &opslevel.Service{
+  	ApiDocumentPath: "",
+- 	Description:     "the second nginx service",
++ 	Description:     "the **second** nginx service",
+  	Framework:       "",
+  	HtmlURL:         "https://app.opslevel.com/services/random-nginx-2",
+  	... // 3 identical fields
+  	ManagedAliases: {"default-random-nginx-2"},
+  	Name:           "random-nginx-2",
+  	Owner: opslevel.TeamId{
+- 		Alias: "platform",
++ 		Alias: "engineering",
+  		Id: strings.Join({
+  			"Z2lkOi8vb3BzbGV2ZWwvVGVhbS8",
+- 			"5NzU5",
++ 			"xMTA5OQ",
+  		}, ""),
+  	},
+  	PreferredApiDocument:       nil,
+  	PreferredApiDocumentSource: nil,
+  	... // 2 identical fields
+  	Tags: &{Nodes: {{Id: "Z2lkOi8vb3BzbGV2ZWwvVGFnLzcxMzA4ODAx", Key: "app.kubernetes.io/name", Value: "proxy"}, {Id: "Z2lkOi8vb3BzbGV2ZWwvVGFnLzcxNjMxODgz", Key: "foo", Value: "bar"}, {Id: "Z2lkOi8vb3BzbGV2ZWwvVGFnLzcxMzA5OTQ2", Key: "goodbye", Value: "world"}, {Id: "Z2lkOi8vb3BzbGV2ZWwvVGFnLzcxNjI2NjEz", Key: "hello", Value: "world"}, ...}, PageInfo: {Start: "MQ", End: "Ng"}, TotalCount: 6},
+  	Tier: {},
+  	Timestamps: opslevel.Timestamps{
+  		CreatedAt: {Time: s"2024-01-16 03:07:03.745338 +0000 UTC"},
+- 		UpdatedAt: iso8601.Time{Time: s"2024-01-18 00:20:03.530134 +0000 UTC"},
++ 		UpdatedAt: iso8601.Time{Time: s"2024-01-18 00:21:57.068903 +0000 UTC"},
+  	},
+  	Tools:        &{Nodes: {}},
+  	Dependencies: nil,
+  	... // 2 identical fields
+  }
+```
+
+> [!TIP]
+> If you don't see any API calls being made when importing or reconciling, it could be that your reconciler is already running in the background! Check `ps aux | grep reconcile` and try `kill -2` on those processes.
+
+**Service Reconcile**
+
+`./kubectl-opslevel service reconcile` will run in the background and should automatically listen for updates.
+
+Reconcile is just like Import except it should run continuously and pickup changes in the background without exiting.
+
+To make reconcile exit, you can send a `kill -2` (SIGINT) or `kill -15` (SIGTERM) to the process. 
+SIGINT is the same as selecting the terminal in the foreground and pressing `CTRL+C`.
+
+**Random note:** if you are using `go run main.go` the exit codes for the process will not be the same as the actual built version.
+
+> [!TIP]
+> Use `./kubectl-opslevel --log-level debug [command] [subcommand]` for more clear output on what's going on.
+
+## Cleanup
+
+If you're using minikube you can simply `minikube stop`.
+
+If all your test services are named `random-nginx-DIGITS` you can use these commands to delete them easily. 
+
+> [!CAUTION]
+> Make sure you are in your dev cluster and that your current OpsLevel API token is for your dev environment.
+
+```
+echo $OPSLEVEL_API_TOKEN
+opslevel list services -o json > services.json
+cat services.json | jq '.[] | select(.name | match("random-nginx-\\d+")) | "\(.id)|\(.name)"' > delete.json
+cat delete.json | tr -d '"' | cut -d '|' -f1 | xargs -n1 echo            # warning: double check the output with echo first
+                                                                         # you can replace echo with `opslevel delete service`
+```

--- a/docs/Local-Development.md
+++ b/docs/Local-Development.md
@@ -26,7 +26,7 @@ Then run:
 ```
 task setup
 cd src                       # from now on this tutorial is going to assume you're in the src/ directory.
-go build .
+go build -o kubectl-opslevel .
 ./kubectl-opslevel           # you can also use `go run main.go` or set an alias like `alias ko='./kubectl-opslevel'`
                              # and `alias bko='go build . && ./kubectl-opslevel'`
 ```

--- a/docs/example-opslevel-k8s.yaml
+++ b/docs/example-opslevel-k8s.yaml
@@ -1,0 +1,20 @@
+version: 1.2.0
+service:
+    import:
+        - selector:
+            apiVersion: v1
+            kind: Pod
+            excludes:
+                - .metadata.namespace == "kube-system"
+                - .metadata.annotations."opslevel.com/ignore"
+          opslevel:
+            name: .metadata.name
+            description: .metadata.annotations."opslevel.com/description"
+            owner: .metadata.annotations."opslevel.com/owner"
+            aliases:
+                - '"\(.metadata.namespace)-\(.metadata.name)"'
+            tags:
+                assign:
+                    - '{"k8s_created": .metadata.creationTimestamp}'
+                    - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/tags"))) | map({(.key | split(".")[2]): .value})'
+                    - .metadata.labels

--- a/docs/example-pod.yaml
+++ b/docs/example-pod.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: random-nginx-1
+  labels:
+    app.kubernetes.io/name: proxy
+  annotations:
+    opslevel.com/description: the first nginx service
+    opslevel.com/owner: platform
+    opslevel.com/lifecycle: beta
+    opslevel.com/tier: tier_2
+    opslevel.com/tags.hello: world
+spec:
+  containers:
+  - name: nginx
+    image: nginx:stable
+    ports:
+      - containerPort: 50001
+        name: http-web-svc-1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: random-nginx-2
+  labels:
+    app.kubernetes.io/name: proxy
+  annotations:
+    opslevel.com/description: the second nginx service
+    opslevel.com/owner: platform
+    opslevel.com/lifecycle: beta
+    opslevel.com/tier: tier_2
+    opslevel.com/tags.hello: world
+spec:
+  containers:
+  - name: nginx
+    image: nginx:stable
+    ports:
+      - containerPort: 50002
+        name: http-web-svc-2
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: random-nginx-3
+  labels:
+    app.kubernetes.io/name: proxy
+  annotations:
+    opslevel.com/description: the third nginx service
+    opslevel.com/owner: platform
+    opslevel.com/lifecycle: beta
+    opslevel.com/tier: tier_2
+    opslevel.com/tags.hello: world
+spec:
+  containers:
+  - name: nginx
+    image: nginx:stable
+    ports:
+      - containerPort: 50003
+        name: http-web-svc-3

--- a/src/cmd/import.go
+++ b/src/cmd/import.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/opslevel/kubectl-opslevel/common"
 	opslevel_jq_parser "github.com/opslevel/opslevel-jq-parser/v2024"
 	"github.com/rs/zerolog/log"
@@ -15,10 +17,11 @@ var importCmd = &cobra.Command{
 		config, err := LoadConfig()
 		cobra.CheckErr(err)
 
+		queue := make(chan opslevel_jq_parser.ServiceRegistration, 1)
+		ctx := InitSignalHandler(context.Background(), queue)
 		client := createOpslevelClient()
 		common.SyncCache(client)
-		queue := make(chan opslevel_jq_parser.ServiceRegistration, 1)
-		common.SetupControllersSync(config, queue)
+		common.SetupControllers(config, queue, 0, ctx)
 		common.ReconcileServices(client, disableServiceCreation, queue)
 		log.Info().Msg("Import Complete")
 	},

--- a/src/cmd/import.go
+++ b/src/cmd/import.go
@@ -18,7 +18,7 @@ var importCmd = &cobra.Command{
 		cobra.CheckErr(err)
 
 		queue := make(chan opslevel_jq_parser.ServiceRegistration, 1)
-		ctx := InitSignalHandler(context.Background(), queue)
+		ctx := common.InitSignalHandler(context.Background(), queue)
 		client := createOpslevelClient()
 		common.SyncCache(client)
 		common.SetupControllers(config, queue, 0, ctx)

--- a/src/cmd/import.go
+++ b/src/cmd/import.go
@@ -18,7 +18,7 @@ var importCmd = &cobra.Command{
 		client := createOpslevelClient()
 		common.SyncCache(client)
 		queue := make(chan opslevel_jq_parser.ServiceRegistration, 1)
-		common.SetupControllers(config, queue, 0)
+		common.SetupControllersSync(config, queue)
 		common.ReconcileServices(client, disableServiceCreation, queue)
 		log.Info().Msg("Import Complete")
 	},

--- a/src/cmd/import.go
+++ b/src/cmd/import.go
@@ -21,7 +21,7 @@ var importCmd = &cobra.Command{
 		ctx := common.InitSignalHandler(context.Background(), queue)
 		client := createOpslevelClient()
 		common.SyncCache(client)
-		common.SetupControllers(config, queue, 0, ctx)
+		common.SetupControllers(ctx, config, queue, 0)
 		common.ReconcileServices(client, disableServiceCreation, queue)
 		log.Info().Msg("Import Complete")
 	},

--- a/src/cmd/preview.go
+++ b/src/cmd/preview.go
@@ -37,7 +37,7 @@ If the optional argument SAMPLES_COUNT=0 this will print out everything.`,
 		ctx := common.InitSignalHandler(context.Background(), queue)
 		client := createOpslevelClient()
 		common.SyncCache(client)
-		common.SetupControllers(config, queue, 0, ctx)
+		common.SetupControllers(ctx, config, queue, 0)
 		PrintServices(IsTextOutput(), sampleCount, queue)
 	},
 }

--- a/src/cmd/preview.go
+++ b/src/cmd/preview.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -32,10 +33,11 @@ If the optional argument SAMPLES_COUNT=0 this will print out everything.`,
 		config, err := LoadConfig()
 		cobra.CheckErr(err)
 
+		queue := make(chan opslevel_jq_parser.ServiceRegistration, 1)
+		ctx := InitSignalHandler(context.Background(), queue)
 		client := createOpslevelClient()
 		common.SyncCache(client)
-		queue := make(chan opslevel_jq_parser.ServiceRegistration, 1)
-		common.SetupControllersSync(config, queue)
+		common.SetupControllers(config, queue, 0, ctx)
 		PrintServices(IsTextOutput(), sampleCount, queue)
 	},
 }
@@ -64,7 +66,7 @@ func PrintServices(isTextOutput bool, samples int, queue <-chan opslevel_jq_pars
 	if isTextOutput {
 		var servicesCount int = len(*services)
 		if samples <= 0 || samples >= servicesCount {
-			fmt.Println("This is the full list of services detected in your cluster.")
+			fmt.Printf("This is the full list of %d services detected in your cluster.\n", servicesCount)
 		} else {
 			fmt.Printf("This is randomly selected list of %d / %d services detected in your cluster.\n", samples, servicesCount)
 			fmt.Println("If you want to see the full list of services detected, pass SAMPLES_COUNT=0.")

--- a/src/cmd/preview.go
+++ b/src/cmd/preview.go
@@ -35,7 +35,7 @@ If the optional argument SAMPLES_COUNT=0 this will print out everything.`,
 		client := createOpslevelClient()
 		common.SyncCache(client)
 		queue := make(chan opslevel_jq_parser.ServiceRegistration, 1)
-		common.SetupControllers(config, queue, 0)
+		common.SetupControllersSync(config, queue)
 		PrintServices(IsTextOutput(), sampleCount, queue)
 	},
 }

--- a/src/cmd/preview.go
+++ b/src/cmd/preview.go
@@ -34,7 +34,7 @@ If the optional argument SAMPLES_COUNT=0 this will print out everything.`,
 		cobra.CheckErr(err)
 
 		queue := make(chan opslevel_jq_parser.ServiceRegistration, 1)
-		ctx := InitSignalHandler(context.Background(), queue)
+		ctx := common.InitSignalHandler(context.Background(), queue)
 		client := createOpslevelClient()
 		common.SyncCache(client)
 		common.SetupControllers(config, queue, 0, ctx)

--- a/src/cmd/reconcile.go
+++ b/src/cmd/reconcile.go
@@ -24,12 +24,12 @@ var reconcileCmd = &cobra.Command{
 		config, err := LoadConfig()
 		cobra.CheckErr(err)
 
+		queue := make(chan opslevel_jq_parser.ServiceRegistration, 1)
+		ctx := InitSignalHandler(context.Background(), queue)
 		client := createOpslevelClient()
 		common.SyncCache(client)
 		common.SyncCaches(createOpslevelClient(), resync)
-		queue := make(chan opslevel_jq_parser.ServiceRegistration, 1)
-		reconcilerCtx, _ := context.WithCancel(context.Background()) // TODO: cancel on SIGINT/SIGTERM
-		common.SetupControllers(config, queue, resync, reconcilerCtx)
+		common.SetupControllers(config, queue, resync, ctx)
 		common.ReconcileServices(client, disableServiceCreation, queue)
 	},
 }

--- a/src/cmd/reconcile.go
+++ b/src/cmd/reconcile.go
@@ -25,7 +25,7 @@ var reconcileCmd = &cobra.Command{
 		cobra.CheckErr(err)
 
 		queue := make(chan opslevel_jq_parser.ServiceRegistration, 1)
-		ctx := InitSignalHandler(context.Background(), queue)
+		ctx := common.InitSignalHandler(context.Background(), queue)
 		client := createOpslevelClient()
 		common.SyncCache(client)
 		common.SyncCaches(createOpslevelClient(), resync)

--- a/src/cmd/reconcile.go
+++ b/src/cmd/reconcile.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"time"
 
 	opslevel_jq_parser "github.com/opslevel/opslevel-jq-parser/v2024"
@@ -27,7 +28,8 @@ var reconcileCmd = &cobra.Command{
 		common.SyncCache(client)
 		common.SyncCaches(createOpslevelClient(), resync)
 		queue := make(chan opslevel_jq_parser.ServiceRegistration, 1)
-		common.SetupControllers(config, queue, resync)
+		reconcilerCtx, _ := context.WithCancel(context.Background()) // TODO: cancel on SIGINT/SIGTERM
+		common.SetupControllers(config, queue, resync, reconcilerCtx)
 		common.ReconcileServices(client, disableServiceCreation, queue)
 	},
 }

--- a/src/cmd/reconcile.go
+++ b/src/cmd/reconcile.go
@@ -29,7 +29,7 @@ var reconcileCmd = &cobra.Command{
 		client := createOpslevelClient()
 		common.SyncCache(client)
 		common.SyncCaches(createOpslevelClient(), resync)
-		common.SetupControllers(config, queue, resync, ctx)
+		common.SetupControllers(ctx, config, queue, resync)
 		common.ReconcileServices(client, disableServiceCreation, queue)
 	},
 }

--- a/src/cmd/signal.go
+++ b/src/cmd/signal.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	opslevel_jq_parser "github.com/opslevel/opslevel-jq-parser/v2024"
+	"github.com/rs/zerolog/log"
+)
+
+func InitSignalHandler(parent context.Context, queue chan<- opslevel_jq_parser.ServiceRegistration) context.Context {
+	ctx, cancel := context.WithCancel(parent)
+	closeChannel := make(chan os.Signal, 1)
+	signal.Notify(closeChannel, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-closeChannel
+		log.Info().Str("signal", sig.String()).Msg("Handling interruption")
+		cancel()
+		close(queue)
+	}()
+	return ctx
+}

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -12,13 +12,8 @@ type Import struct {
 	OpslevelConfig opslevel_jq_parser.ServiceRegistrationConfig `yaml:"opslevel" json:"opslevel" mapstructure:"opslevel"`
 }
 
-type Collect struct {
-	SelectorConfig opslevel_k8s_controller.K8SSelector `yaml:"selector" json:"selector" mapstructure:"selector"`
-}
-
 type Service struct {
-	Import  []Import  `json:"import"`
-	Collect []Collect `json:"collect"`
+	Import []Import `json:"import"`
 }
 
 type Config struct {
@@ -50,13 +45,6 @@ service:
             - .metadata.labels
           create: # tag with the same key name but with a different value with be added to the service
             - '{"environment": .spec.template.metadata.labels.environment}'
-  collect:
-    - selector: # This limits what data we look at in Kubernetes
-        apiVersion: "apps/v1" # only supports resources found in 'kubectl api-resources --verbs="get,list"'
-        kind: Deployment
-        excludes: # filters out resources if any expression returns truthy
-          - .metadata.namespace == "kube-system"
-          - .metadata.annotations."opslevel.com/ignore"
 `
 
 var ConfigSample = `#Sample Opslevel CLI Config
@@ -102,13 +90,6 @@ service:
           - .metadata.annotations.repo
           # find annotations with format: opslevel.com/repo.<displayname>.<repo.subpath.dots.turned.to.forwardslash>: <opslevel repo alias>
           - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/repo"))) | map({"name": .key | split(".")[2], "directory": .key | split(".")[3:] | join("/"), "repo": .value})'
-  collect:
-    - selector: # This limits what data we look at in Kubernetes
-        apiVersion: "apps/v1" # only supports resources found in 'kubectl api-resources --verbs="get,list"'
-        kind: Deployment
-        excludes: # filters out resources if any expression returns truthy
-          - .metadata.namespace == "kube-system"
-          - .metadata.annotations."opslevel.com/ignore"
 `
 
 func ParseConfig(data string) (*Config, error) {

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -12,8 +12,13 @@ type Import struct {
 	OpslevelConfig opslevel_jq_parser.ServiceRegistrationConfig `yaml:"opslevel" json:"opslevel" mapstructure:"opslevel"`
 }
 
+type Collect struct {
+	SelectorConfig opslevel_k8s_controller.K8SSelector `yaml:"selector" json:"selector" mapstructure:"selector"`
+}
+
 type Service struct {
-	Import []Import `json:"import"`
+	Import  []Import  `json:"import"`
+	Collect []Collect `json:"collect"`
 }
 
 type Config struct {
@@ -45,6 +50,13 @@ service:
             - .metadata.labels
           create: # tag with the same key name but with a different value with be added to the service
             - '{"environment": .spec.template.metadata.labels.environment}'
+  collect:
+    - selector: # This limits what data we look at in Kubernetes
+        apiVersion: "apps/v1" # only supports resources found in 'kubectl api-resources --verbs="get,list"'
+        kind: Deployment
+        excludes: # filters out resources if any expression returns truthy
+          - .metadata.namespace == "kube-system"
+          - .metadata.annotations."opslevel.com/ignore"
 `
 
 var ConfigSample = `#Sample Opslevel CLI Config
@@ -90,6 +102,13 @@ service:
           - .metadata.annotations.repo
           # find annotations with format: opslevel.com/repo.<displayname>.<repo.subpath.dots.turned.to.forwardslash>: <opslevel repo alias>
           - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/repo"))) | map({"name": .key | split(".")[2], "directory": .key | split(".")[3:] | join("/"), "repo": .value})'
+  collect:
+    - selector: # This limits what data we look at in Kubernetes
+        apiVersion: "apps/v1" # only supports resources found in 'kubectl api-resources --verbs="get,list"'
+        kind: Deployment
+        excludes: # filters out resources if any expression returns truthy
+          - .metadata.namespace == "kube-system"
+          - .metadata.annotations."opslevel.com/ignore"
 `
 
 func ParseConfig(data string) (*Config, error) {

--- a/src/common/parser.go
+++ b/src/common/parser.go
@@ -68,7 +68,7 @@ func SetupControllers(ctx context.Context, config *Config, queue chan<- opslevel
 			if wg != nil {
 				wg.Add(1)
 			}
-			controller.Start(wg, ctx)
+			controller.Start(ctx, wg)
 		}
 		if resync <= 0 {
 			wg.Wait()

--- a/src/common/parser.go
+++ b/src/common/parser.go
@@ -50,7 +50,7 @@ func NewParserHandler(config Import, queue chan<- opslevel_jq_parser.ServiceRegi
 	}
 }
 
-func SetupControllers(config *Config, queue chan<- opslevel_jq_parser.ServiceRegistration, resync time.Duration, ctx context.Context) {
+func SetupControllers(ctx context.Context, config *Config, queue chan<- opslevel_jq_parser.ServiceRegistration, resync time.Duration) {
 	go func() {
 		var wg *sync.WaitGroup
 		if resync <= 0 {

--- a/src/common/parser.go
+++ b/src/common/parser.go
@@ -50,45 +50,26 @@ func NewParserHandler(config Import, queue chan<- opslevel_jq_parser.ServiceRegi
 	}
 }
 
-func newController(importConfig Import, queue chan<- opslevel_jq_parser.ServiceRegistration, sync time.Duration) (*opslevel_k8s_controller.K8SController, error) {
-	controller, err := opslevel_k8s_controller.NewK8SController(importConfig.SelectorConfig, sync)
-	if err != nil {
-		return nil, err
-	}
-	callback := NewParserHandler(importConfig, queue)
-	controller.OnAdd = callback
-	controller.OnUpdate = callback
-	return controller, err
-}
-
-// SetupControllersSync returns the pointer to a K8sController that will run only once.
-func SetupControllersSync(config *Config, queue chan<- opslevel_jq_parser.ServiceRegistration) {
-	go func() {
-		var wg sync.WaitGroup
-		for _, importConfig := range config.Service.Import {
-			controller, err := newController(importConfig, queue, 0)
-			if err != nil {
-				log.Error().Err(err).Msg("failed to create k8s controller")
-				continue
-			}
-			wg.Add(1)
-			controller.RunOnce(&wg)
-		}
-		wg.Wait()
-		close(queue)
-	}()
-}
-
-// SetupControllers returns the pointer to a K8sController that will run until the context is cancelled.
 func SetupControllers(config *Config, queue chan<- opslevel_jq_parser.ServiceRegistration, resync time.Duration, ctx context.Context) {
 	go func() {
+		var wg *sync.WaitGroup
+		if resync <= 0 {
+			wg = &sync.WaitGroup{}
+		}
 		for _, importConfig := range config.Service.Import {
-			controller, err := newController(importConfig, queue, resync)
+			controller, err := opslevel_k8s_controller.NewK8SController(importConfig.SelectorConfig, resync)
 			if err != nil {
 				log.Error().Err(err).Msg("failed to create k8s controller")
 				continue
 			}
-			controller.Run(ctx)
+			callback := NewParserHandler(importConfig, queue)
+			controller.OnAdd = callback
+			controller.OnUpdate = callback
+			controller.Start(wg, ctx)
+		}
+		if resync <= 0 {
+			wg.Wait()
+			close(queue)
 		}
 	}()
 }

--- a/src/common/parser.go
+++ b/src/common/parser.go
@@ -65,6 +65,9 @@ func SetupControllers(config *Config, queue chan<- opslevel_jq_parser.ServiceReg
 			callback := NewParserHandler(importConfig, queue)
 			controller.OnAdd = callback
 			controller.OnUpdate = callback
+			if wg != nil {
+				wg.Add(1)
+			}
 			controller.Start(wg, ctx)
 		}
 		if resync <= 0 {

--- a/src/common/signal.go
+++ b/src/common/signal.go
@@ -1,4 +1,4 @@
-package cmd
+package common
 
 import (
 	"context"


### PR DESCRIPTION
## Issues

Backend change: https://github.com/OpsLevel/opslevel-k8s-controller/pull/20

https://github.com/OpsLevel/team-platform/issues/184

https://github.com/OpsLevel/team-platform/issues/183

## Changelog

- [x] Add a signal handler that will stop processing the current event on SIGINT/SIGTERM
- [x] Rip out signal handler code from opslevel-common
- [x] Make a `changie` entry

## Tophatting

<details>

Preview - notice that the program doesn't just crash but gracefully exits after processing 1 entry.

```
$ go run main.go service preview
2:24PM INF [/v1/pods] Informer is ready and synced
taking a massive 5 sec break for you to test out the interrupt
^C2:24PM INF Handling interruption signal=interrupt
The following data was found in your Kubernetes cluster ...

[
    {
        "Name": "random-nginx-1",
        "Description": "i hope the stack works",
        "Owner": "platform",
        "Aliases": [
            "default-random-nginx-1"
        ],
        "TagAssigns": [
            {
                "key": "k8s_created",
                "value": "2024-01-16T03:05:51Z"
            },
            {
                "key": "hello",
                "value": "world"
            },
            {
                "key": "queue",
                "value": "gone"
            },
            {
                "key": "stack",
                "value": "added"
            },
            {
                "key": "app.kubernetes.io/name",
                "value": "proxy"
            }
        ]
    }
]

This is the full list of 1 services detected in your cluster.

If you're happy with the above data you can reconcile it with OpsLevel by running:

 OPSLEVEL_API_TOKEN=XXX kubectl opslevel service import

Otherwise, please adjust the config file and rerun this command
```

Import - same result.

```
$ go run main.go service import
2:24PM INF [/v1/pods] Informer is ready and synced
taking a massive 5 sec break for you to test out the interrupt
2:24PM INF [random-nginx-1] No changes detected to fields - skipping update
2:24PM INF [random-nginx-1] All tags already assigned to service.
^C2:24PM INF Handling interruption signal=interrupt
2:24PM INF Import Complete
```

Reconcile.

```
$ go run main.go --log-level debug service reconcile
2:25PM DBG maxprocs: Leaving GOMAXPROCS=10: CPU quota undefined
2:25PM DBG Caching 'Tier' lookup table from API ...
2:25PM DBG Caching 'Lifecycle' lookup table from API ...
2:25PM DBG Caching 'Team' lookup table from API ...
2:25PM INF [/v1/pods] Informer is ready and synced
2:25PM DBG mainloop: running from top queue_addr=0x140000b2aa0 queue_len=10
taking a massive 5 sec break for you to test out the interrupt
2:25PM INF [random-nginx-1] No changes detected to fields - skipping update
2:25PM INF [random-nginx-1] All tags already assigned to service.
2:25PM DBG mainloop: running from top queue_addr=0x140000b2aa0 queue_len=9
taking a massive 5 sec break for you to test out the interrupt
2:25PM INF [random-nginx-2] No changes detected to fields - skipping update
2:25PM INF [random-nginx-2] All tags already assigned to service.
2:25PM DBG mainloop: running from top queue_addr=0x140000b2aa0 queue_len=8
taking a massive 5 sec break for you to test out the interrupt
2:25PM INF [random-nginx-3] No changes detected to fields - skipping update
2:25PM INF [random-nginx-3] All tags already assigned to service.
^C2:25PM INF Handling interruption signal=interrupt
```

</details>
