### PR TITLE
update brew formula from goreleaser to go build on brew install

### DIFF
--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -24,11 +24,16 @@ brews:
     license: "MIT"
     folder: Formula
     dependencies:
+      - name: go
       - name: jq
     install: |
-      bin.install "kubectl-opslevel"
+      ENV["CGO_ENABLED"] = "1"
+      ENV["CGO_CFLAGS"] = "-I#{Formula["jq"].opt_include}"
+      ENV["CGO_LDFLAGS"] = "-L#{Formula["jq"].opt_lib}"
+
+      system "go", "build", *std_go_args(output: bin/"kubectl-opslevel", ldflags: "-s -w"), "./src"
     test: |
-      system "#{bin}/kubectl-opslevel version"
+      system "#{bin}/kubectl-opslevel", "version"
     repository:
       owner: opslevel
       name: homebrew-tap

--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -25,6 +25,7 @@ brews:
     folder: Formula
     dependencies:
       - name: go
+        version: ">=1.21.0"
       - name: jq
     install: |
       ENV["CGO_ENABLED"] = "1"


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

I _think_ this will work... 🤔 

This changes the brew Formula that goreleaser generates:
- Add `go` as a dependency on `brew install opslevel/tap/kubectl`
- I'm fairly certain we're expecting folks using this to also have `jq` managed by brew

- [X] List your changes here
- [ ] Make a `changie` entry, N/A brew Formula update via goreleaser

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
