### PR TITLE
update task ci, finds jq include,lib paths

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,11 +13,16 @@ env:
 
 tasks:
   ci:
-    desc: Workflow to run in CI
+    desc: Workflow to run in CI - MacOS only
+    deps: [brew-install-jq]
+    vars:
+      CGO_CFLAGS:
+        sh: echo -I$(dirname $(dirname $(which jq)))/include
+      CGO_LDFLAGS:
+        sh: echo -L$(dirname $(dirname $(which jq)))/lib
     cmds:
       - task: workspace
       - task: has-latest-opslevel-dependencies
-      - which jq > /dev/null
       - task: install-gofumpt
       - task: install-golangci-lint
       - task: lint
@@ -128,7 +133,7 @@ tasks:
   brew-install-jq:
     internal: true
     platforms: [darwin]
-    cmds: ["brew install jq"]
+    cmds: ["which jq > /dev/null || brew install jq"]
     preconditions:
       - sh: 'which brew'
         msg: '"brew" needed to install "jq"- see https://brew.sh'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,11 +21,11 @@ tasks:
       CGO_LDFLAGS:
         sh: echo -L$(dirname $(dirname $(which jq)))/lib
     cmds:
-      - task: workspace
-      - task: has-latest-opslevel-dependencies
       - task: install-gofumpt
       - task: install-golangci-lint
       - task: lint
+      - task: workspace
+      - task: has-latest-opslevel-dependencies
       - task: test
 
   lint:


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

`task ci` had hardcoded paths to `jq`'s lib and include paths. This is a problem in CI and this update should help with that

- [X] List your changes here
- [ ] Make a `changie` entry, N/A CI only

## Tophatting

`task ci` - still works 🎉  
