### PR TITLE
make version based on latest git tag and commit

### DIFF
--- a/.changes/unreleased/Feature-20240131-093229.yaml
+++ b/.changes/unreleased/Feature-20240131-093229.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add --short flag to version command
+time: 2024-01-31T09:32:29.191804-06:00

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,7 +105,11 @@ jobs:
           IMAGE: "public.ecr.aws/opslevel/kubectl-opslevel"
         run: |
           cd ./src
-          docker build -t "${IMAGE}:latest" -t "${IMAGE}:${RELEASE_VERSION}" .
+          docker build \
+            -t "${IMAGE}:latest" \
+            -t "${IMAGE}:${RELEASE_VERSION}" \
+            --build-arg="VERSION=${RELEASE_VERSION}" \
+            --build-arg="COMMIT=${GITHUB_SHA::7}" .
           docker push "${IMAGE}:latest"
           docker push "${IMAGE}:${RELEASE_VERSION}"
 

--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -32,7 +32,7 @@ brews:
       ENV["CGO_CFLAGS"] = "-I#{Formula["jq"].opt_include}"
       ENV["CGO_LDFLAGS"] = "-L#{Formula["jq"].opt_lib}"
 
-      system "go", "build", *std_go_args(output: bin/"kubectl-opslevel", ldflags: "-s -w"), "./src"
+      system "go", "build", *std_go_args(output: bin/"kubectl-opslevel", ldflags: "-s -w -X main.version={{.Tag}} -X main.commit={{.ShortCommit}}"), "./src"
     test: |
       system "#{bin}/kubectl-opslevel", "version"
     repository:

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -12,8 +12,10 @@ RUN go mod download
 
 COPY . /src
 
+ARG COMMIT
+ARG VERSION
 RUN GOOS=linux \
-    go build -ldflags="-s -w" -o kubectl-opslevel main.go
+  go build -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" -o kubectl-opslevel main.go
 
 FROM golang:1.21 as release
 COPY --from=builder /src/kubectl-opslevel /usr/local/bin

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -35,7 +35,8 @@ var rootCmd = &cobra.Command{
 	Long:    `Opslevel Commandline Tools`,
 }
 
-func Execute(v string) {
+func Execute(c string, v string) {
+	commit = c
 	version = v
 	cobra.CheckErr(rootCmd.Execute())
 }

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -46,15 +46,6 @@ func runVersion(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getGoInfo() GoInfo {
-	return GoInfo{
-		Version:  runtime.Version(),
-		Compiler: runtime.Compiler,
-		OS:       runtime.GOOS,
-		Arch:     runtime.GOARCH,
-	}
-}
-
 func init() {
 	rootCmd.AddCommand(versionCmd)
 }

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -1,20 +1,58 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"runtime"
 
 	"github.com/spf13/cobra"
 )
 
-var version = "development"
+var commit, version string
+
+type Build struct {
+	Version string `json:"version,omitempty"`
+	Commit  string `json:"git_commit,omitempty"`
+	GoInfo  GoInfo `json:"go,omitempty"`
+}
+
+type GoInfo struct {
+	Version  string `json:"version,omitempty"`
+	Compiler string `json:"compiler,omitempty"`
+	OS       string `json:"os,omitempty"`
+	Arch     string `json:"arch,omitempty"`
+}
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
 	Long:  `Print version information`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(version)
-	},
+	RunE:  runVersion,
+}
+
+func runVersion(cmd *cobra.Command, args []string) error {
+	goInfo := GoInfo{
+		Version:  runtime.Version(),
+		Compiler: runtime.Compiler,
+		OS:       runtime.GOOS,
+		Arch:     runtime.GOARCH,
+	}
+	build := Build{Commit: commit, GoInfo: goInfo, Version: version}
+	versionInfo, err := json.MarshalIndent(build, "", "    ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(versionInfo))
+	return nil
+}
+
+func getGoInfo() GoInfo {
+	return GoInfo{
+		Version:  runtime.Version(),
+		Compiler: runtime.Compiler,
+		OS:       runtime.GOOS,
+		Arch:     runtime.GOARCH,
+	}
 }
 
 func init() {

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -8,7 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var commit, version string
+var (
+	commit, version  string
+	shortVersionFlag bool
+)
 
 type Build struct {
 	Version string `json:"version,omitempty"`
@@ -31,6 +34,10 @@ var versionCmd = &cobra.Command{
 }
 
 func runVersion(cmd *cobra.Command, args []string) error {
+	if shortVersionFlag {
+		fmt.Printf("%s-%s\n", version, commit)
+		return nil
+	}
 	goInfo := GoInfo{
 		Version:  runtime.Version(),
 		Compiler: runtime.Compiler,
@@ -48,4 +55,5 @@ func runVersion(cmd *cobra.Command, args []string) error {
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
+	versionCmd.PersistentFlags().BoolVar(&shortVersionFlag, "short", false, "Print only version number")
 }

--- a/src/main.go
+++ b/src/main.go
@@ -1,10 +1,6 @@
 package main
 
-import (
-	"fmt"
-
-	"github.com/opslevel/kubectl-opslevel/cmd"
-)
+import "github.com/opslevel/kubectl-opslevel/cmd"
 
 var (
 	version = "dev"
@@ -12,5 +8,5 @@ var (
 )
 
 func main() {
-	cmd.Execute(fmt.Sprintf("%s-%0.12s", version, commit))
+	cmd.Execute(commit, version)
 }


### PR DESCRIPTION
## Issues

[Unify Version output across all tools and libraries](https://github.com/OpsLevel/team-platform/issues/213)

With the latest release, `kubectl opslevel version` does not output what we want.

## Changelog

Specify release version at `go build` time with `-X main.version=${VERSION} -X main.commit=${COMMIT}` flags.
Most of the changes in `src/cmd/version.go` are copies from our cli. `kubectl opslevel version`

Add `--short` to `version` command

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

```bash
cd <kubectl-opslevel-repo>/src
docker build --build-arg="VERSION=$(git describe)" --build-arg="COMMIT=$(git rev-parse --short HEAD)" -t test-version-cmd -f Dockerfile . 
docker run --rm test-version-cmd version
```
This outputs:
```json
{
    "commit": "7a58cfe",
    "version": "v2024.1.27",
    "go": {
        "version": "go1.21.6",
        "compiler": "gc",
        "os": "linux",
        "arch": "arm64"
    }
}

```
Note `"arch"`. Since `kubectl-opslevel` uses a machine's native `jq`, this is relevant and can alternatively be `amd64`.