### PR TITLE
Db/add opslevel metadata to version cmd

### DIFF
--- a/.changes/unreleased/Feature-20240201-142836.yaml
+++ b/.changes/unreleased/Feature-20240201-142836.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add opslevel app metadata to version command
+time: 2024-02-01T14:28:36.750113-06:00

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -47,7 +47,7 @@ func init() {
 	rootCmd.PersistentFlags().String("log-level", "INFO", "overrides environment variable 'OPSLEVEL_LOG_LEVEL' (options [\"ERROR\", \"WARN\", \"INFO\", \"DEBUG\"])")
 	rootCmd.PersistentFlags().StringVar(&apiToken, "api-token", "", "The OpsLevel API Token. Overrides environment variable 'OPSLEVEL_API_TOKEN' and the argument 'api-token-path'")
 	rootCmd.PersistentFlags().StringVar(&apiTokenFile, "api-token-path", "", "Absolute path to a file containing the OpsLevel API Token. Overrides environment variable 'OPSLEVEL_API_TOKEN'")
-	rootCmd.PersistentFlags().String("api-url", "https://api.opslevel.com/", "The OpsLevel API Url. Overrides environment variable 'OPSLEVEL_API_URL'")
+	rootCmd.PersistentFlags().String("api-url", "https://app.opslevel.com/", "The OpsLevel API Url. Overrides environment variable 'OPSLEVEL_API_URL'")
 	rootCmd.PersistentFlags().IntVar(&apiTimeout, "api-timeout", 40, "The OpsLevel API timeout in seconds. Overrides environment variable 'OPSLEVEL_API_TIMEOUT'")
 	rootCmd.PersistentFlags().IntP("workers", "w", -1, "Sets the number of workers for API call processing. -1 == # CPU cores (cgroup aware). Overrides environment variable 'OPSLEVEL_WORKERS'")
 	rootCmd.PersistentFlags().StringP("output", "o", "text", "Output format.  One of: json|text")


### PR DESCRIPTION
## Issues

[Unify Version output across all tools and libraries](https://github.com/OpsLevel/team-platform/issues/213)

## Changelog

Match output of `opslevel version` by adding `opslevel` app metadata.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

`kubectl opslevel version` returns:

`dev` and `none` are local values
```json
{
    "version": "dev",
    "git_commit": "none",
    "go": {
        "version": "go1.21.5",
        "compiler": "gc",
        "os": "darwin",
        "arch": "arm64"
    },
    "opslevel": {
        "app_commit": "971f1da2225e",
        "app_version": "1706917368"
    }
}

```
