### PR TITLE
fix task ci, pulls submodules before linting, skip linting submodules

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,8 +24,8 @@ tasks:
       - task: install-gofumpt
       - task: install-golangci-lint
       - task: install-nilaway
-      - task: lint
       - task: workspace
+      - task: lint
       - task: has-latest-opslevel-dependencies
       - task: test
 

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -1,0 +1,3 @@
+run:
+  skip-dirs:
+    - submodules


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

`task lint` was failing if a code from submodules are not found (pre-release code). We need to pull submodules before linting, but we also don't want CI to fail if linting some submodule code fails, so we don't lint that anymore

- [X] List your changes here
- [ ] Make a `changie` entry, N/A taskfile only

## Tophatting

`task ci`
