### PR TITLE
Add forgotten changelogs to latest release

### DIFF
--- a/.changes/v2024.3.18.md
+++ b/.changes/v2024.3.18.md
@@ -1,6 +1,10 @@
 ## [March 18, 2024](https://github.com/OpsLevel/kubectl-opslevel/compare/v2024.3.4...v2024.3.18)
 ### Bugfix
 * Fix bug where service fields are being set to "null" if they are not defined in Kubernetes or in the user's config
+* Fix bug where not all system aliases were being checked during service updates
+### Feature
+* Log the `ServiceUpdateInput` sent to the API before service updates
+* Log the diff between services before and after updates
 ### Dependency
 * Bump google.golang.org/protobuf from 1.32.0 to 1.33.0 in /src
 ## Docker Image


### PR DESCRIPTION
This PR updates the current release log for to be more accurate. 

In the future we might want to look up which specific release changed the way logs look or how service aliases are compared.

[Code diff of last release](https://github.com/OpsLevel/kubectl-opslevel/compare/v2024.3.4...v2024.3.18)

[Last release v2024.3.18](https://github.com/OpsLevel/kubectl-opslevel/releases/tag/v2024.3.18)

TODO post merge:

- [ ] Update release text in GitHub