### PR TITLE
Potential fix for customer reported potential race condition

### DIFF
--- a/src/common/reconciler.go
+++ b/src/common/reconciler.go
@@ -93,6 +93,11 @@ func (r *ServiceReconciler) lookupService(registration opslevel_jq_parser.Servic
 		} else if foundService == nil {
 			log.Warn().Msgf("unexpected happened: got service with alias '%s' but the result is nil", alias)
 		} else if foundService.Id == "" {
+			if len(foundService.Aliases) == 1 {
+				// If this happens and there is only 1 alias to check we cannot assume the service doesn't exist
+				// because it seems like our API has a race condition looking up the service
+				return nil, serviceAliasesResult_APIErrorHappened
+			}
 			log.Warn().Msgf("unexpected happened: got service with alias '%s' but the result has no ID", alias)
 		} else {
 			// happy path


### PR DESCRIPTION
## Issues
https://github.com/OpsLevel/team-platform/issues/380

The customer was seeing

```
unexpected happened: got service with alias 'totem-appdir' but the result has no ID
```

But if this is the only alias too lookup by and since there is no actual API error we default to creating the service.   It seems there might be an API race condition with service lookup.  So this detects that situation and defers the reconciliation untill next time where hopefully it won't have this problem.
