### PR TITLE
Add ability to disable service name updates

### DIFF
--- a/.changes/unreleased/Feature-20240903-173336.yaml
+++ b/.changes/unreleased/Feature-20240903-173336.yaml
@@ -1,0 +1,4 @@
+kind: Feature
+body: Add flag on `service reconcile` to disable service name updates which can in
+  certain cases cause unwanted alias generation
+time: 2024-09-03T17:33:36.909815-05:00

--- a/.changes/unreleased/Feature-20240903-173435.yaml
+++ b/.changes/unreleased/Feature-20240903-173435.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: 'BREAKING CHANGE: Set the default for the tool to not update service names'
+time: 2024-09-03T17:34:35.541775-05:00

--- a/src/cmd/import.go
+++ b/src/cmd/import.go
@@ -22,7 +22,7 @@ var importCmd = &cobra.Command{
 		client := createOpslevelClient()
 		common.SyncCache(client)
 		common.SetupControllers(ctx, config, queue, 0)
-		common.ReconcileServices(client, disableServiceCreation, queue)
+		common.ReconcileServices(client, disableServiceCreation, enableServiceNameUpdate, queue)
 		log.Info().Msg("Import Complete")
 	},
 }

--- a/src/cmd/reconcile.go
+++ b/src/cmd/reconcile.go
@@ -10,7 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var reconcileResyncInterval int
+var (
+	reconcileResyncInterval  int
+	disableServiceNameUpdate bool
+)
 
 var reconcileCmd = &cobra.Command{
 	Use:   "reconcile",
@@ -37,4 +40,5 @@ var reconcileCmd = &cobra.Command{
 func init() {
 	serviceCmd.AddCommand(reconcileCmd)
 	reconcileCmd.Flags().IntVar(&reconcileResyncInterval, "resync", 24, "The amount (in hours) before a full resync of the kubernetes cluster happens with OpsLevel.")
+	reconcileCmd.Flags().BoolVar(&disableServiceNameUpdate, "disable-service-name-update", true, "Turns off updating the service name.")
 }

--- a/src/cmd/reconcile.go
+++ b/src/cmd/reconcile.go
@@ -12,7 +12,6 @@ import (
 
 var (
 	reconcileResyncInterval int
-	enableServiceNameUpdate bool
 )
 
 var reconcileCmd = &cobra.Command{
@@ -40,5 +39,4 @@ var reconcileCmd = &cobra.Command{
 func init() {
 	serviceCmd.AddCommand(reconcileCmd)
 	reconcileCmd.Flags().IntVar(&reconcileResyncInterval, "resync", 24, "The amount (in hours) before a full resync of the kubernetes cluster happens with OpsLevel.")
-	reconcileCmd.Flags().BoolVar(&enableServiceNameUpdate, "enable-service-name-update", false, "Turns on updating the service name.")
 }

--- a/src/cmd/reconcile.go
+++ b/src/cmd/reconcile.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	reconcileResyncInterval  int
-	disableServiceNameUpdate bool
+	reconcileResyncInterval int
+	enableServiceNameUpdate bool
 )
 
 var reconcileCmd = &cobra.Command{
@@ -33,12 +33,12 @@ var reconcileCmd = &cobra.Command{
 		common.SyncCache(client)
 		common.SyncCaches(createOpslevelClient(), resync)
 		common.SetupControllers(ctx, config, queue, resync)
-		common.ReconcileServices(client, disableServiceCreation, queue)
+		common.ReconcileServices(client, disableServiceCreation, enableServiceNameUpdate, queue)
 	},
 }
 
 func init() {
 	serviceCmd.AddCommand(reconcileCmd)
 	reconcileCmd.Flags().IntVar(&reconcileResyncInterval, "resync", 24, "The amount (in hours) before a full resync of the kubernetes cluster happens with OpsLevel.")
-	reconcileCmd.Flags().BoolVar(&disableServiceNameUpdate, "disable-service-name-update", true, "Turns off updating the service name.")
+	reconcileCmd.Flags().BoolVar(&enableServiceNameUpdate, "enable-service-name-update", false, "Turns on updating the service name.")
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -53,7 +53,7 @@ func init() {
 	rootCmd.PersistentFlags().IntP("workers", "w", -1, "Sets the number of workers for API call processing. -1 == # CPU cores (cgroup aware). Overrides environment variable 'OPSLEVEL_WORKERS'")
 	rootCmd.PersistentFlags().StringP("output", "o", "text", "Output format.  One of: json|text")
 	rootCmd.PersistentFlags().Bool("disable-service-create", false, "Turns off automatic service creation (service data will still be reconciled). Overrides environment variable 'OPSLEVEL_DISABLE_SERVICE_CREATE'.")
-	rootCmd.Flags().BoolVar(&enableServiceNameUpdate, "enable-service-name-update", false, "Turns on updating the service name.")
+	rootCmd.PersistentFlags().BoolVar(&enableServiceNameUpdate, "enable-service-name-update", false, "Turns on updating the service name.")
 
 	cobra.CheckErr(viper.BindPFlags(rootCmd.PersistentFlags()))
 	cobra.CheckErr(viper.BindEnv("log-format", "OPSLEVEL_LOG_FORMAT", "OL_LOG_FORMAT", "OL_LOGFORMAT"))

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -19,13 +19,14 @@ import (
 )
 
 var (
-	apiToken               string
-	apiTokenFile           string
-	apiTimeout             int
-	cfgFile                string
-	concurrency            int
-	outputFormat           string
-	disableServiceCreation bool
+	apiToken                string
+	apiTokenFile            string
+	apiTimeout              int
+	cfgFile                 string
+	concurrency             int
+	outputFormat            string
+	disableServiceCreation  bool
+	enableServiceNameUpdate bool
 )
 
 var rootCmd = &cobra.Command{
@@ -52,6 +53,7 @@ func init() {
 	rootCmd.PersistentFlags().IntP("workers", "w", -1, "Sets the number of workers for API call processing. -1 == # CPU cores (cgroup aware). Overrides environment variable 'OPSLEVEL_WORKERS'")
 	rootCmd.PersistentFlags().StringP("output", "o", "text", "Output format.  One of: json|text")
 	rootCmd.PersistentFlags().Bool("disable-service-create", false, "Turns off automatic service creation (service data will still be reconciled). Overrides environment variable 'OPSLEVEL_DISABLE_SERVICE_CREATE'.")
+	rootCmd.Flags().BoolVar(&enableServiceNameUpdate, "enable-service-name-update", false, "Turns on updating the service name.")
 
 	cobra.CheckErr(viper.BindPFlags(rootCmd.PersistentFlags()))
 	cobra.CheckErr(viper.BindEnv("log-format", "OPSLEVEL_LOG_FORMAT", "OL_LOG_FORMAT", "OL_LOGFORMAT"))

--- a/src/common/parser.go
+++ b/src/common/parser.go
@@ -21,8 +21,8 @@ func AggregateServices(queue <-chan opslevel_jq_parser.ServiceRegistration) *[]o
 	return &services
 }
 
-func ReconcileServices(client *opslevel.Client, disableServiceCreation, disableServiceNameUpdate bool, queue <-chan opslevel_jq_parser.ServiceRegistration) {
-	reconciler := NewServiceReconciler(NewOpslevelClient(client), disableServiceCreation, disableServiceNameUpdate)
+func ReconcileServices(client *opslevel.Client, disableServiceCreation, enableServiceNameUpdate bool, queue <-chan opslevel_jq_parser.ServiceRegistration) {
+	reconciler := NewServiceReconciler(NewOpslevelClient(client), disableServiceCreation, enableServiceNameUpdate)
 	for registration := range queue {
 		err := reconciler.Reconcile(registration)
 		if err != nil {

--- a/src/common/parser.go
+++ b/src/common/parser.go
@@ -21,8 +21,8 @@ func AggregateServices(queue <-chan opslevel_jq_parser.ServiceRegistration) *[]o
 	return &services
 }
 
-func ReconcileServices(client *opslevel.Client, disableServiceCreation bool, queue <-chan opslevel_jq_parser.ServiceRegistration) {
-	reconciler := NewServiceReconciler(NewOpslevelClient(client), disableServiceCreation)
+func ReconcileServices(client *opslevel.Client, disableServiceCreation, disableServiceNameUpdate bool, queue <-chan opslevel_jq_parser.ServiceRegistration) {
+	reconciler := NewServiceReconciler(NewOpslevelClient(client), disableServiceCreation, disableServiceNameUpdate)
 	for registration := range queue {
 		err := reconciler.Reconcile(registration)
 		if err != nil {

--- a/src/common/reconciler.go
+++ b/src/common/reconciler.go
@@ -24,14 +24,16 @@ const (
 )
 
 type ServiceReconciler struct {
-	client                 *OpslevelClient
-	disableServiceCreation bool
+	client                   *OpslevelClient
+	disableServiceCreation   bool
+	disableServiceNameUpdate bool
 }
 
-func NewServiceReconciler(client *OpslevelClient, disableServiceCreation bool) *ServiceReconciler {
+func NewServiceReconciler(client *OpslevelClient, disableServiceCreation, disableServiceNameUpdate bool) *ServiceReconciler {
 	return &ServiceReconciler{
-		client:                 client,
-		disableServiceCreation: disableServiceCreation,
+		client:                   client,
+		disableServiceCreation:   disableServiceCreation,
+		disableServiceNameUpdate: disableServiceNameUpdate,
 	}
 }
 
@@ -237,7 +239,7 @@ func (r *ServiceReconciler) updateService(service *opslevel.Service, registratio
 			log.Warn().Msgf("[%s] Unable to find 'Lifecycle' with alias '%s'", service.Name, registration.Lifecycle)
 		}
 	}
-	if registration.Name != "" && registration.Name != service.Name {
+	if !r.disableServiceNameUpdate && registration.Name != "" && registration.Name != service.Name {
 		updateServiceInput.Name = opslevel.RefOf(registration.Name)
 	}
 	if registration.Owner != "" && registration.Owner != service.Owner.Alias {

--- a/src/common/reconciler.go
+++ b/src/common/reconciler.go
@@ -24,16 +24,16 @@ const (
 )
 
 type ServiceReconciler struct {
-	client                   *OpslevelClient
-	disableServiceCreation   bool
-	disableServiceNameUpdate bool
+	client                  *OpslevelClient
+	disableServiceCreation  bool
+	enableServiceNameUpdate bool
 }
 
-func NewServiceReconciler(client *OpslevelClient, disableServiceCreation, disableServiceNameUpdate bool) *ServiceReconciler {
+func NewServiceReconciler(client *OpslevelClient, disableServiceCreation, enableServiceNameUpdate bool) *ServiceReconciler {
 	return &ServiceReconciler{
-		client:                   client,
-		disableServiceCreation:   disableServiceCreation,
-		disableServiceNameUpdate: disableServiceNameUpdate,
+		client:                  client,
+		disableServiceCreation:  disableServiceCreation,
+		enableServiceNameUpdate: enableServiceNameUpdate,
 	}
 }
 
@@ -239,7 +239,7 @@ func (r *ServiceReconciler) updateService(service *opslevel.Service, registratio
 			log.Warn().Msgf("[%s] Unable to find 'Lifecycle' with alias '%s'", service.Name, registration.Lifecycle)
 		}
 	}
-	if !r.disableServiceNameUpdate && registration.Name != "" && registration.Name != service.Name {
+	if r.enableServiceNameUpdate && registration.Name != "" && registration.Name != service.Name {
 		updateServiceInput.Name = opslevel.RefOf(registration.Name)
 	}
 	if registration.Owner != "" && registration.Owner != service.Owner.Alias {

--- a/src/common/reconciler_test.go
+++ b/src/common/reconciler_test.go
@@ -99,7 +99,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				Name:    "test",
 				Aliases: []string{},
 			},
-			reconciler: common.NewServiceReconciler(&common.OpslevelClient{}, false),
+			reconciler: common.NewServiceReconciler(&common.OpslevelClient{}, false, true),
 			assert: func(t *testing.T, err error) {
 				autopilot.Equals(t, "[test] found 0 aliases from kubernetes data", err.Error())
 			},
@@ -119,7 +119,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				GetRepositoryWithAliasHandler: func(alias string) (*opslevel.Repository, error) {
 					return nil, fmt.Errorf("api error")
 				},
-			}, false),
+			}, false, true),
 			assert: func(t *testing.T, err error) {
 				autopilot.Ok(t, err)
 			},
@@ -133,7 +133,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				GetServiceHandler: func(alias string) (*opslevel.Service, error) {
 					return nil, fmt.Errorf("api error")
 				},
-			}, false),
+			}, false, true),
 			assert: func(t *testing.T, err error) {
 				autopilot.Equals(t, "[test] api error during service lookup by alias.  unable to guarantee service was found or not ... skipping reconciliation", err.Error())
 			},
@@ -159,7 +159,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				CreateTagHandler: func(input opslevel.TagCreateInput) error {
 					panic("should not be called")
 				},
-			}, false),
+			}, false, true),
 			assert: func(t *testing.T, err error) {
 				autopilot.Ok(t, err)
 			},
@@ -198,7 +198,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				UpdateServiceRepositoryHandler: func(input opslevel.ServiceRepositoryUpdateInput) error {
 					panic("should not be called")
 				},
-			}, false),
+			}, false, true),
 			assert: func(t *testing.T, err error) {
 				autopilot.Ok(t, err)
 			},
@@ -239,7 +239,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				UpdateServiceRepositoryHandler: func(input opslevel.ServiceRepositoryUpdateInput) error {
 					panic("should not be called")
 				},
-			}, true),
+			}, true, true),
 			assert: func(t *testing.T, err error) {
 				autopilot.Ok(t, err)
 			},
@@ -277,7 +277,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				UpdateServiceRepositoryHandler: func(input opslevel.ServiceRepositoryUpdateInput) error {
 					panic("should not be called")
 				},
-			}, false),
+			}, false, true),
 			assert: func(t *testing.T, err error) {
 				autopilot.Ok(t, err)
 			},
@@ -315,7 +315,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				UpdateServiceRepositoryHandler: func(input opslevel.ServiceRepositoryUpdateInput) error {
 					panic("should not be called")
 				},
-			}, false),
+			}, false, true),
 			assert: func(t *testing.T, err error) {
 				autopilot.Ok(t, err)
 			},
@@ -361,7 +361,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				UpdateServiceRepositoryHandler: func(input opslevel.ServiceRepositoryUpdateInput) error {
 					panic("should not be called")
 				},
-			}, false),
+			}, false, true),
 			assert: func(t *testing.T, err error) {
 				autopilot.Ok(t, err)
 			},
@@ -416,7 +416,7 @@ func TestReconcilerReconcile(t *testing.T) {
 				UpdateServiceRepositoryHandler: func(input opslevel.ServiceRepositoryUpdateInput) error {
 					panic("should not be called")
 				},
-			}, false),
+			}, false, true),
 			assert: func(t *testing.T, err error) {
 				autopilot.Ok(t, err)
 			},
@@ -481,7 +481,7 @@ func Test_Reconciler_RepoNotInOpsLevel(t *testing.T) {
 		UpdateServiceRepositoryHandler: func(input opslevel.ServiceRepositoryUpdateInput) error {
 			panic("should not be called")
 		},
-	}, true)
+	}, true, true)
 	reconcilerError := reconciler.Reconcile(testRegistration)
 
 	autopilot.Ok(t, reconcilerError)
@@ -551,7 +551,7 @@ func Test_Reconciler_RepoIsAttached(t *testing.T) {
 		UpdateServiceRepositoryHandler: func(input opslevel.ServiceRepositoryUpdateInput) error {
 			panic("should not be called")
 		},
-	}, true)
+	}, true, true)
 	reconcilerError := reconciler.Reconcile(testRegistration)
 
 	autopilot.Ok(t, reconcilerError)
@@ -619,7 +619,7 @@ func Test_Reconciler_RepoNeedsCreate(t *testing.T) {
 		UpdateServiceRepositoryHandler: func(input opslevel.ServiceRepositoryUpdateInput) error {
 			panic("should not be called")
 		},
-	}, true)
+	}, true, true)
 	reconcilerError := reconciler.Reconcile(testRegistration)
 
 	autopilot.Ok(t, reconcilerError)
@@ -690,7 +690,7 @@ func Test_Reconciler_RepoNeedsCreateBasic(t *testing.T) {
 		UpdateServiceRepositoryHandler: func(input opslevel.ServiceRepositoryUpdateInput) error {
 			panic("should not be called")
 		},
-	}, true)
+	}, true, true)
 	reconcilerError := reconciler.Reconcile(testRegistration)
 
 	autopilot.Ok(t, reconcilerError)
@@ -770,7 +770,7 @@ func Test_Reconciler_RepoNeedsUpdate(t *testing.T) {
 			autopilot.Equals(t, "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZVJlcG9zaXRvcnkvMTAwNDc", string(input.Id))
 			return nil
 		},
-	}, true)
+	}, true, true)
 	reconcilerError := reconciler.Reconcile(testRegistration)
 
 	autopilot.Ok(t, reconcilerError)
@@ -785,7 +785,7 @@ func Test_Reconciler_ContainsAllTags(t *testing.T) {
 		tags   []opslevel.Tag
 		result bool
 	}
-	reconciler := common.NewServiceReconciler(&common.OpslevelClient{}, false)
+	reconciler := common.NewServiceReconciler(&common.OpslevelClient{}, false, true)
 	cases := map[string]TestCase{
 		"Is True When All Tags Overlap": {
 			input: []opslevel.TagInput{
@@ -900,7 +900,7 @@ func Test_Reconciler_HandleTools(t *testing.T) {
 			toolsCreated = append(toolsCreated, tool)
 			return nil
 		},
-	}, false)
+	}, false, true)
 	// Act
 	err := reconciler.Reconcile(registration)
 	autopilot.Ok(t, err)
@@ -951,7 +951,7 @@ func Test_Reconciler_HandleProperties(t *testing.T) {
 			results = append(results, input)
 			return nil
 		},
-	}, false)
+	}, false, true)
 
 	// Act
 	err := reconciler.Reconcile(registration)


### PR DESCRIPTION
Resolves #306

### Problem

During service update names can change and in certain situation can cause unwanted alias generation to have `_2` put on the end.

### Solution

Add a flag which disables updating the service name to prevent this in certain situations.  This default is likely better then before so it is the new default.

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [X] This PR has no user interface changes or has already received approval from product management to change the interface.
- [X] Make a [changie](https://github.com/OpsLevel/cli/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
