### PR TITLE
fix for sample testing

### DIFF
--- a/.changes/unreleased/Feature-20240904-151102.yaml
+++ b/.changes/unreleased/Feature-20240904-151102.yaml
@@ -1,0 +1,4 @@
+kind: Feature
+body: When the tool loads if it doesn't find a valid configuration file it will fallback
+  to the default printed out by the `config sample` command
+time: 2024-09-04T15:11:02.347334-05:00

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"os"
 
 	"github.com/opslevel/kubectl-opslevel/common"
@@ -89,7 +90,8 @@ func readConfig() []byte {
 		res, err = os.ReadFile(cfgFile)
 	}
 	if err != nil {
-		panic(err)
+		log.Warn().Err(err).Msg("could not read config file - falling back to default")
+		return []byte(common.ConfigSample)
 	}
 	return res
 }


### PR DESCRIPTION
Resolves #

### Problem

When you start up the tool `service import` or `service reconcile` it fails when no configuration file is found or passed in.

### Solution

Fallback to the sample configuration to make getting started with the tool easy - also makes manual testing easier.

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [x] Make a [changie](https://github.com/OpsLevel/cli/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
