### PR TITLE
bias towards consolidating a service running in multiple namespaces into a single service in OL

### DIFF
--- a/src/common/configs/config_sample.yaml
+++ b/src/common/configs/config_sample.yaml
@@ -10,6 +10,7 @@ service:
           - .metadata.annotations."opslevel.com/ignore"
       opslevel: # This is how you map your kubernetes data to opslevel service
         aliases: # This is how we identify the services again during reconciliation - please make sure they are unique
+          - .metadata.name # Consolidate the same service in multiple namespaces into a single record
           - '"k8s:\(.metadata.name)-\(.metadata.namespace)"'
           - '"\(.metadata.namespace)-\(.metadata.name)"'
         description: .metadata.annotations."opslevel.com/description"

--- a/src/common/configs/config_simple.yaml
+++ b/src/common/configs/config_simple.yaml
@@ -10,6 +10,7 @@ service:
           - .metadata.annotations."opslevel.com/ignore"
       opslevel: # This is how you map your kubernetes data to opslevel service
         aliases: # This is how we identify the services again during reconciliation - please make sure they are unique
+          - .metadata.name # Consolidate the same service in multiple namespaces into a single record
           - '"k8s:\(.metadata.name)-\(.metadata.namespace)"'
         name: .metadata.name
         owner: .metadata.namespace


### PR DESCRIPTION
Slack context: https://jk-labs.slack.com/archives/C01K732BV51/p1726162518585529

propose the aliases stanza be updated to be:

```
            aliases:
                - .metadata.name
                - '"k8s:\(.metadata.name)-\(.metadata.namespace)"'
                - '"\(.metadata.namespace)-\(.metadata.name)"'
 ```

This would bias our syncer to consolidate these services under one service record in OL, and the aliases with the namespace suffix is still preserved. (IMO, we want to bias towards “one record for the service running across multiple namespaces” and customers can change their mind if they want)

Resolves #

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/cli/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
